### PR TITLE
migrate to jdk21 and enable full annotation processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,8 +168,10 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.12.1</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>${maven.compiler.release}</source>
+                    <target>${maven.compiler.release}</target>
+                    <release>${maven.compiler.release}</release>
+                    <proc>full</proc>
                 </configuration>
             </plugin>
             <plugin>
@@ -470,6 +472,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>21</maven.compiler.release>
     </properties>
     
     <profiles>
@@ -507,7 +510,7 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <source>17</source>
+                            <source>${maven.compiler.release}</source>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
migrate to jdk21 and enable full annotation processor (disabled by default)