### PR TITLE
Add AI Inline Completion Shortcut Option

### DIFF
--- a/src/main/java/io/github/jeddict/ai/completion/JeddictCompletionProvider.java
+++ b/src/main/java/io/github/jeddict/ai/completion/JeddictCompletionProvider.java
@@ -161,7 +161,8 @@ public class JeddictCompletionProvider implements CompletionProvider {
         if (!prefsManager.isSmartCodeEnabled()) {
             return null;
         }
-        if (type == COMPLETION_QUERY_TYPE) {
+        if ((prefsManager.isCompletionAllQueryType() && type == COMPLETION_ALL_QUERY_TYPE)
+                || (!prefsManager.isCompletionAllQueryType() && type == COMPLETION_QUERY_TYPE)) {
             return new AsyncCompletionTask(new JeddictCompletionQuery(type, component.getSelectionStart()), component);
         }
         return null;

--- a/src/main/java/io/github/jeddict/ai/settings/AIAssistancePanel.form
+++ b/src/main/java/io/github/jeddict/ai/settings/AIAssistancePanel.form
@@ -22,6 +22,10 @@
 -->
 
 <Form version="1.9" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
+  <NonVisualComponents>
+    <Component class="javax.swing.ButtonGroup" name="aiInlineCompletionShortcutGroup">
+    </Component>
+  </NonVisualComponents>
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="1"/>
     <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
@@ -1153,6 +1157,51 @@
                   <AuxValues>
                     <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;AIClassContext&gt;"/>
                   </AuxValues>
+                </Component>
+              </SubComponents>
+            </Container>
+            <Container class="javax.swing.JLayeredPane" name="snippetPane1">
+
+              <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout">
+                <Property name="alignment" type="int" value="0"/>
+              </Layout>
+              <SubComponents>
+                <Component class="javax.swing.JLabel" name="aiInlineCompletionShortcutLabel">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                      <ResourceString bundle="io/github/jeddict/ai/settings/Bundle.properties" key="AIAssistancePanel.aiInlineCompletionShortcutLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                    </Property>
+                    <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                      <ResourceString bundle="io/github/jeddict/ai/settings/Bundle.properties" key="AIAssistancePanel.aiInlineCompletionShortcut.toolTipText" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                    </Property>
+                  </Properties>
+                </Component>
+                <Component class="javax.swing.JRadioButton" name="ctrlSpaceRadioButton">
+                  <Properties>
+                    <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
+                      <ComponentRef name="aiInlineCompletionShortcutGroup"/>
+                    </Property>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                      <ResourceString bundle="io/github/jeddict/ai/settings/Bundle.properties" key="AIAssistancePanel.ctrlSpaceRadioButton.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                    </Property>
+                    <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                      <ResourceString bundle="io/github/jeddict/ai/settings/Bundle.properties" key="AIAssistancePanel.aiInlineCompletionShortcut.toolTipText" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                    </Property>
+                  </Properties>
+                </Component>
+                <Component class="javax.swing.JRadioButton" name="ctrlAltSpaceRadioButton">
+                  <Properties>
+                    <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
+                      <ComponentRef name="aiInlineCompletionShortcutGroup"/>
+                    </Property>
+                    <Property name="selected" type="boolean" value="true"/>
+                    <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                      <ResourceString bundle="io/github/jeddict/ai/settings/Bundle.properties" key="AIAssistancePanel.ctrlAltSpaceRadioButton.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                    </Property>
+                    <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                      <ResourceString bundle="io/github/jeddict/ai/settings/Bundle.properties" key="AIAssistancePanel.aiInlineCompletionShortcut.toolTipText" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                    </Property>
+                  </Properties>
                 </Component>
               </SubComponents>
             </Container>

--- a/src/main/java/io/github/jeddict/ai/settings/AIAssistancePanel.java
+++ b/src/main/java/io/github/jeddict/ai/settings/AIAssistancePanel.java
@@ -64,6 +64,7 @@ final class AIAssistancePanel extends javax.swing.JPanel {
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 
+        aiInlineCompletionShortcutGroup = new javax.swing.ButtonGroup();
         jTabbedPane1 = new javax.swing.JTabbedPane();
         providersPane = new javax.swing.JLayeredPane();
         providerParentPane = new javax.swing.JLayeredPane();
@@ -166,6 +167,10 @@ final class AIAssistancePanel extends javax.swing.JPanel {
         varContextLabel = new javax.swing.JLabel();
         varContextHelp = new javax.swing.JLabel();
         varContextComboBox = new javax.swing.JComboBox<>();
+        snippetPane1 = new javax.swing.JLayeredPane();
+        aiInlineCompletionShortcutLabel = new javax.swing.JLabel();
+        ctrlSpaceRadioButton = new javax.swing.JRadioButton();
+        ctrlAltSpaceRadioButton = new javax.swing.JRadioButton();
         snippetPane = new javax.swing.JLayeredPane();
         showDescriptionCheckBox = new javax.swing.JCheckBox();
         cachePane = new javax.swing.JLayeredPane();
@@ -689,6 +694,25 @@ final class AIAssistancePanel extends javax.swing.JPanel {
 
         inlineCompletionPane.add(varContextPane);
 
+        snippetPane1.setLayout(new java.awt.FlowLayout(java.awt.FlowLayout.LEFT));
+
+        org.openide.awt.Mnemonics.setLocalizedText(aiInlineCompletionShortcutLabel, org.openide.util.NbBundle.getMessage(AIAssistancePanel.class, "AIAssistancePanel.aiInlineCompletionShortcutLabel.text")); // NOI18N
+        aiInlineCompletionShortcutLabel.setToolTipText(org.openide.util.NbBundle.getMessage(AIAssistancePanel.class, "AIAssistancePanel.aiInlineCompletionShortcut.toolTipText")); // NOI18N
+        snippetPane1.add(aiInlineCompletionShortcutLabel);
+
+        aiInlineCompletionShortcutGroup.add(ctrlSpaceRadioButton);
+        org.openide.awt.Mnemonics.setLocalizedText(ctrlSpaceRadioButton, org.openide.util.NbBundle.getMessage(AIAssistancePanel.class, "AIAssistancePanel.ctrlSpaceRadioButton.text")); // NOI18N
+        ctrlSpaceRadioButton.setToolTipText(org.openide.util.NbBundle.getMessage(AIAssistancePanel.class, "AIAssistancePanel.aiInlineCompletionShortcut.toolTipText")); // NOI18N
+        snippetPane1.add(ctrlSpaceRadioButton);
+
+        aiInlineCompletionShortcutGroup.add(ctrlAltSpaceRadioButton);
+        ctrlAltSpaceRadioButton.setSelected(true);
+        org.openide.awt.Mnemonics.setLocalizedText(ctrlAltSpaceRadioButton, org.openide.util.NbBundle.getMessage(AIAssistancePanel.class, "AIAssistancePanel.ctrlAltSpaceRadioButton.text")); // NOI18N
+        ctrlAltSpaceRadioButton.setToolTipText(org.openide.util.NbBundle.getMessage(AIAssistancePanel.class, "AIAssistancePanel.aiInlineCompletionShortcut.toolTipText")); // NOI18N
+        snippetPane1.add(ctrlAltSpaceRadioButton);
+
+        inlineCompletionPane.add(snippetPane1);
+
         snippetPane.setLayout(new java.awt.FlowLayout(java.awt.FlowLayout.LEFT));
 
         org.openide.awt.Mnemonics.setLocalizedText(showDescriptionCheckBox, org.openide.util.NbBundle.getMessage(AIAssistancePanel.class, "AIAssistancePanel.showDescriptionCheckBox.text")); // NOI18N
@@ -1109,6 +1133,8 @@ final class AIAssistancePanel extends javax.swing.JPanel {
 
         providerComboBox.setSelectedItem(preferencesManager.getProvider());
         modelComboBox.setSelectedItem(preferencesManager.getModel());
+        ctrlSpaceRadioButton.setSelected(!preferencesManager.isCompletionAllQueryType());
+        ctrlAltSpaceRadioButton.setSelected(preferencesManager.isCompletionAllQueryType());
         showDescriptionCheckBox.setSelected(preferencesManager.isDescriptionEnabled());
         fileExtField.setText(preferencesManager.getFileExtensionToInclude());
         excludeJavadocCommentsCheckBox.setSelected(preferencesManager.isExcludeJavadocEnabled());
@@ -1144,6 +1170,7 @@ final class AIAssistancePanel extends javax.swing.JPanel {
         preferencesManager.setInlineHintEnabled(enableInlineHintCheckBox.isSelected());
         preferencesManager.setHintsEnabled(enableHintsCheckBox.isSelected());
         preferencesManager.setSmartCodeEnabled(enableSmartCodeCheckBox.isSelected());
+        preferencesManager.setCompletionAllQueryType(ctrlAltSpaceRadioButton.isSelected());
         preferencesManager.setDescriptionEnabled(showDescriptionCheckBox.isSelected());
         preferencesManager.setFileExtensionToInclude(fileExtField.getText());
         preferencesManager.setExcludeDirs(getCommaSeparatedValues(excludeTableModel));
@@ -1340,6 +1367,8 @@ final class AIAssistancePanel extends javax.swing.JPanel {
     private javax.swing.JLayeredPane activationPane;
     private javax.swing.JLayeredPane activationParentPane;
     private javax.swing.JCheckBox aiAssistantActivationCheckBox;
+    private javax.swing.ButtonGroup aiInlineCompletionShortcutGroup;
+    private javax.swing.JLabel aiInlineCompletionShortcutLabel;
     private javax.swing.JCheckBox allowCodeExecution;
     private javax.swing.JPasswordField apiKeyField;
     private javax.swing.JLabel apiKeyInfo;
@@ -1361,6 +1390,8 @@ final class AIAssistancePanel extends javax.swing.JPanel {
     private javax.swing.JLayeredPane classContextPane;
     private javax.swing.JButton cleanDataButton;
     private javax.swing.JLayeredPane commonSettingsParentPane1;
+    private javax.swing.JRadioButton ctrlAltSpaceRadioButton;
+    private javax.swing.JRadioButton ctrlSpaceRadioButton;
     private javax.swing.JLayeredPane customHeadersPane;
     private javax.swing.JScrollPane customHeadersScrollPane;
     private javax.swing.JTable customHeadersTable;
@@ -1433,6 +1464,7 @@ final class AIAssistancePanel extends javax.swing.JPanel {
     private javax.swing.JLayeredPane seedPane;
     private javax.swing.JCheckBox showDescriptionCheckBox;
     private javax.swing.JLayeredPane snippetPane;
+    private javax.swing.JLayeredPane snippetPane1;
     private javax.swing.JCheckBox stream;
     private javax.swing.JTextField temperature;
     private javax.swing.JLabel temperatureLabel;

--- a/src/main/java/io/github/jeddict/ai/settings/PreferencesManager.java
+++ b/src/main/java/io/github/jeddict/ai/settings/PreferencesManager.java
@@ -346,6 +346,14 @@ public class PreferencesManager {
         preferences.putBoolean("enableSmartCode", enabled);
     }
 
+     public boolean isCompletionAllQueryType() {
+        return preferences.getBoolean("enableCompletionAllQueryType", true);
+    }
+
+    public void setCompletionAllQueryType(boolean enabled) {
+        preferences.putBoolean("enableCompletionAllQueryType", enabled);
+    }
+
     public boolean isDescriptionEnabled() {
         return preferences.getBoolean("showDecription", true);
     }

--- a/src/main/resources/io/github/jeddict/ai/settings/Bundle.properties
+++ b/src/main/resources/io/github/jeddict/ai/settings/Bundle.properties
@@ -112,3 +112,7 @@ AIAssistancePanel.maxRetries.toolTipText=Maximum number of retries for failed AP
 AIAssistancePanel.headerKey.text=Custom Header Key
 AIAssistancePanel.headerValue.text=Custom Header Value
 AIAssistancePanel.customHeadersTable.toolTipText=Custom headers can be to send specific metadata or authentication token
+AIAssistancePanel.aiInlineCompletionShortcut.toolTipText=Select the keyboard shortcut to trigger AI-powered inline code completions.
+AIAssistancePanel.aiInlineCompletionShortcutLabel.text=AI-Powered Inline Completion Shortcut:
+AIAssistancePanel.ctrlSpaceRadioButton.text=CTRL+SPACE
+AIAssistancePanel.ctrlAltSpaceRadioButton.text=CTRL+ALT+SPACE


### PR DESCRIPTION
This PR adds a UI option to configure the keyboard shortcut for triggering AI-based inline completions. The user can select between:

 - CTRL+SPACE
 - CTRL+ALT+SPACE  (default)
 
 
![image](https://github.com/user-attachments/assets/d571a25b-2daf-49f9-8aeb-d3e5730c287c)


 Fixes #86 