### PR TITLE
Minor fix to the Ask/Agent option

### DIFF
--- a/src/main/java/io/github/jeddict/ai/agent/AssistantAction.java
+++ b/src/main/java/io/github/jeddict/ai/agent/AssistantAction.java
@@ -1,6 +1,17 @@
-/*
- * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
- * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+/**
+ * Copyright 2025 the original author or authors from the Jeddict project (https://jeddict.github.io/).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package io.github.jeddict.ai.agent;
 
@@ -10,7 +21,7 @@ package io.github.jeddict.ai.agent;
  */
 public enum AssistantAction {
     ASK("Ask"),
-    BUILD("Build");
+    BUILD("Agent");
 
     private final String displayName;
 


### PR DESCRIPTION
The current implementation shows Build as one of the options in Ask/Agent mode as the tooltip suggests:

<img width="469" height="170" alt="image" src="https://github.com/user-attachments/assets/8abbdd89-010b-4d68-a7e5-58340efe2379" />

This PR fixes it and adds also the project header to the class.