### PR TITLE
Fix for submit button not updating the icon in case of errors

### DIFF
--- a/src/main/java/io/github/jeddict/ai/lang/JeddictStreamHandler.java
+++ b/src/main/java/io/github/jeddict/ai/lang/JeddictStreamHandler.java
@@ -84,15 +84,17 @@ public abstract class JeddictStreamHandler implements StreamingResponseHandler<A
         LOGGER.log(Level.SEVERE, "Exception in JeddictStreamHandler", throwable);
         // Update UI on the Event Dispatch Thread
         SwingUtilities.invokeLater(() -> {
+            final String error =  "[Error] An error occurred: " + throwable.getMessage();
             if (textArea != null) {
-                textArea.append("\n\n[Error] An error occurred: " + throwable.getMessage());
+                textArea.append("\n\n" + error);
             } else {
                 // If textArea not yet initialized, clear and create one to show error
                 topComponent.clear();
                 JTextArea errorArea = topComponent.createTextAreaPane();
-                errorArea.setText("[Error] An error occurred: " + throwable.getMessage());
+                errorArea.setText(error);
                 textArea = errorArea;
-    }
+            }
+            onComplete(error);
             if (handle != null) {
                 handle.finish();
             }
@@ -113,6 +115,6 @@ public abstract class JeddictStreamHandler implements StreamingResponseHandler<A
     }
 
     public abstract void onComplete(String response);
-    
-    
+
+
 }


### PR DESCRIPTION
Fixed the issue that when an error occurs, the submit icon remains the spinning circle instead of go back to the triangle