### PR TITLE
Bump langchain to 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,7 +419,7 @@
         <dependency>
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-openide-util</artifactId>
-            <version>RELEASE130</version>
+            <version>RELEASE260</version>
         </dependency>
 
         <dependency>
@@ -475,7 +475,7 @@
         <dependency>
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-openide-awt</artifactId>
-            <version>RELEASE130</version>
+            <version>RELEASE260</version>
         </dependency>
         <dependency>
             <groupId>org.netbeans.api</groupId>
@@ -555,7 +555,7 @@
         <dependency>
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-openide-io</artifactId>
-            <version>RELEASE130</version>
+            <version>RELEASE260</version>
         </dependency>
     </dependencies>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -208,37 +208,42 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-open-ai</artifactId>
-            <version>0.36.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-ollama</artifactId>
-            <version>0.36.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-local-ai</artifactId>
-            <version>0.36.0</version>
+            <version>1.3.0-beta9</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-mistral-ai</artifactId>
-            <version>0.36.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-anthropic</artifactId>
-            <version>0.36.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-google-ai-gemini</artifactId>
-            <version>0.36.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
-            <version>0.36.0</version>
+            <version>1.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-http-client-jdk</artifactId>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.knuddels</groupId>

--- a/src/main/java/io/github/jeddict/ai/lang/ChatModelBaseBuilder.java
+++ b/src/main/java/io/github/jeddict/ai/lang/ChatModelBaseBuilder.java
@@ -83,14 +83,6 @@ public interface ChatModelBaseBuilder<T> {
     ChatModelBaseBuilder<T> topP(final Double topP);
 
     /**
-     * Sets the maximum number of retry attempts for failed requests.
-     *
-     * @param maxRetries The maximum number of retries
-     * @return The builder instance
-     */
-    ChatModelBaseBuilder<T> maxRetries(final Integer maxRetries);
-
-    /**
      * Sets the maximum number of tokens in the output.
      *
      * @param maxOutputTokens The maximum number of output tokens

--- a/src/main/java/io/github/jeddict/ai/lang/ChatModelBuilder.java
+++ b/src/main/java/io/github/jeddict/ai/lang/ChatModelBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.github.jeddict.ai.lang;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import java.time.Duration;
 import java.util.Map;
 
@@ -24,10 +24,10 @@ import java.util.Map;
  * chat-based language models. It inherits all configuration methods from the base builder while specifically targeting ChatLanguageModel as the build output type.
  *
  * @author Francois Steyn
- * @see ChatLanguageModel
+ * @see ChatModel
  * @see ChatModelBaseBuilder
  */
-public interface ChatModelBuilder extends ChatModelBaseBuilder<ChatLanguageModel> {
+public interface ChatModelBuilder extends ChatModelBaseBuilder<ChatModel> {
 
     @Override
     ChatModelBuilder baseUrl(final String baseUrl);
@@ -49,9 +49,6 @@ public interface ChatModelBuilder extends ChatModelBaseBuilder<ChatLanguageModel
 
     @Override
     ChatModelBuilder topP(final Double topP);
-
-    @Override
-    ChatModelBuilder maxRetries(final Integer maxRetries);
 
     @Override
     ChatModelBuilder maxOutputTokens(final Integer maxOutputTokens);
@@ -90,6 +87,8 @@ public interface ChatModelBuilder extends ChatModelBaseBuilder<ChatLanguageModel
     ChatModelBuilder allowCodeExecution(final boolean allowCodeExecution);
 
     @Override
-    ChatLanguageModel build();
+    ChatModel build();
+
+    ChatModelBuilder maxRetries(final Integer maxRetries);
 
 }

--- a/src/main/java/io/github/jeddict/ai/lang/ChatModelStreamingBuilder.java
+++ b/src/main/java/io/github/jeddict/ai/lang/ChatModelStreamingBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.github.jeddict.ai.lang;
 
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import java.time.Duration;
 import java.util.Map;
 
@@ -25,10 +25,10 @@ import java.util.Map;
  * streaming functionality enables real-time, token-by-token response generation.
  *
  * @author Francois Steyn
- * @see StreamingChatLanguageModel
+ * @see StreamingChatModel
  * @see ChatModelBaseBuilder
  */
-public interface ChatModelStreamingBuilder extends ChatModelBaseBuilder<StreamingChatLanguageModel> {
+public interface ChatModelStreamingBuilder extends ChatModelBaseBuilder<StreamingChatModel> {
 
     @Override
     ChatModelStreamingBuilder baseUrl(final String baseUrl);
@@ -50,9 +50,6 @@ public interface ChatModelStreamingBuilder extends ChatModelBaseBuilder<Streamin
 
     @Override
     ChatModelStreamingBuilder topP(final Double topP);
-
-    @Override
-    ChatModelStreamingBuilder maxRetries(final Integer maxRetries);
 
     @Override
     ChatModelStreamingBuilder maxOutputTokens(final Integer maxOutputTokens);
@@ -91,6 +88,6 @@ public interface ChatModelStreamingBuilder extends ChatModelBaseBuilder<Streamin
     ChatModelStreamingBuilder allowCodeExecution(final boolean allowCodeExecution);
 
     @Override
-    StreamingChatLanguageModel build();
+    StreamingChatModel build();
 
 }

--- a/src/main/java/io/github/jeddict/ai/lang/JeddictChatModelBuilder.java
+++ b/src/main/java/io/github/jeddict/ai/lang/JeddictChatModelBuilder.java
@@ -170,7 +170,7 @@ public class JeddictChatModelBuilder {
 
         setIfValid(builder::temperature, pm.getTemperature(), Double.MIN_VALUE);
         setIfValid(value -> builder.timeout(Duration.ofSeconds(value)), pm.getTimeout(), Integer.MIN_VALUE);
-        if (builder instanceof ChatModelStreamingBuilder) {
+        if (builder instanceof ChatModelBuilder) {
             setIfValid(((ChatModelBuilder)builder)::maxRetries, pm.getMaxRetries(), Integer.MIN_VALUE);
         }
         setIfValid(builder::maxOutputTokens, pm.getMaxOutputTokens(), Integer.MIN_VALUE);
@@ -268,13 +268,19 @@ public class JeddictChatModelBuilder {
             }
         } catch (Exception e) {
             String errorMessage = e.getMessage();
-            if (e.getCause() != null ) {
+            if (e.getCause() != null && e.getCause().getMessage() != null) {
                 //
                 // let's pretend it is a JSON object, if not, ignore it
                 //
-                JSONObject jsonObject = new JSONObject(e.getCause().getMessage());
-                if (jsonObject.has("error") && jsonObject.getJSONObject("error").has("message")) {
-                    errorMessage = jsonObject.getJSONObject("error").getString("message");
+                try {
+                    JSONObject jsonObject = new JSONObject(e.getCause().getMessage());
+                    if (jsonObject.has("error") && jsonObject.getJSONObject("error").has("message")) {
+                        errorMessage = jsonObject.getJSONObject("error").getString("message");
+                    }
+                } catch (Throwable x) {
+                    //
+                    // It was not a proper JSON
+                    //
                 }
             }
             if (errorMessage != null

--- a/src/main/java/io/github/jeddict/ai/lang/JeddictStreamHandler.java
+++ b/src/main/java/io/github/jeddict/ai/lang/JeddictStreamHandler.java
@@ -16,10 +16,12 @@
 package io.github.jeddict.ai.lang;
 
 import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.model.StreamingResponseHandler;
-import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import io.github.jeddict.ai.components.AssistantChat;
 import io.github.jeddict.ai.response.TokenHandler;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.CompletableFuture;
@@ -33,20 +35,18 @@ import org.netbeans.api.progress.ProgressHandle;
  *
  * @author Shiwani Gupta
  */
-public abstract class JeddictStreamHandler implements StreamingResponseHandler<AiMessage> {
+public abstract class JeddictStreamHandler implements StreamingChatResponseHandler {
 
     private final AssistantChat topComponent;
     private boolean init = true;
     private JTextArea textArea;
     private ProgressHandle handle;
     private boolean complete;
-//    protected MarkdownStreamParser parser;
     private static final Logger LOGGER = Logger.getLogger(JeddictStreamHandler.class.getName());
 
 
     public JeddictStreamHandler(AssistantChat topComponent) {
         this.topComponent = topComponent;
-//        parser = new MarkdownStreamParser(block -> {}, topComponent);
     }
 
     public ProgressHandle getProgressHandle() {
@@ -58,16 +58,16 @@ public abstract class JeddictStreamHandler implements StreamingResponseHandler<A
     }
 
     @Override
-    public void onNext(String token) {
+    public void onPartialResponse(String partialResponse) {
+        LOGGER.finest(() -> "partial response received: " + partialResponse);
         if (init) {
             topComponent.clear();
             textArea = topComponent.createTextAreaPane();
-            textArea.setText(token);
+            textArea.setText(partialResponse);
             init = false;
         } else {
-            textArea.append(token);
+            textArea.append(partialResponse);
         }
-//        parser.processToken(token);
     }
 
     public boolean isComplete() {
@@ -76,15 +76,25 @@ public abstract class JeddictStreamHandler implements StreamingResponseHandler<A
 
     @Override
     public void onError(Throwable throwable) {
+        LOGGER.finest(() -> "error received: " + throwable);
         complete = true;
         // Log the error with timestamp and thread info
         String timestamp = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
         String threadName = Thread.currentThread().getName();
         LOGGER.log(Level.SEVERE, "Error occurred at {0} on thread [{1}]", new Object[] { timestamp, threadName });
         LOGGER.log(Level.SEVERE, "Exception in JeddictStreamHandler", throwable);
+
+        //
+        // Build the error message
+        //
+        final StringWriter w = new StringWriter();
+            w.append("An error occurred: " + throwable.getMessage());
+            w.append("\n\nMore details:\n\n");
+            throwable.printStackTrace(new PrintWriter(w));
+        final String error = w.toString();
+
         // Update UI on the Event Dispatch Thread
         SwingUtilities.invokeLater(() -> {
-            final String error =  "[Error] An error occurred: " + throwable.getMessage();
             if (textArea != null) {
                 textArea.append("\n\n" + error);
             } else {
@@ -94,27 +104,24 @@ public abstract class JeddictStreamHandler implements StreamingResponseHandler<A
                 errorArea.setText(error);
                 textArea = errorArea;
             }
-            onComplete(error);
-            if (handle != null) {
-                handle.finish();
-            }
+
+            onCompleteResponse(
+                ChatResponse.builder().aiMessage(new AiMessage(error)).build()
+            );
         });
     }
 
     @Override
-    public void onComplete(Response<AiMessage> out) {
+    public void onCompleteResponse(ChatResponse completeResponse) {
+        LOGGER.finest(() -> "complete response received: " + completeResponse);
         complete = true;
         SwingUtilities.invokeLater(() -> {
-            String response = out.content().text();
+            String response = completeResponse.aiMessage().text();
             if (response != null && !response.isEmpty()) {
                 CompletableFuture.runAsync(() -> TokenHandler.saveOutputToken(response));
-                onComplete(response);
                 handle.finish();
             }
         });
     }
-
-    public abstract void onComplete(String response);
-
 
 }

--- a/src/main/java/io/github/jeddict/ai/lang/impl/AnthropicBuilder.java
+++ b/src/main/java/io/github/jeddict/ai/lang/impl/AnthropicBuilder.java
@@ -16,7 +16,7 @@
 package io.github.jeddict.ai.lang.impl;
 
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import io.github.jeddict.ai.lang.ChatModelBuilder;
 import java.time.Duration;
 import java.util.Map;
@@ -155,7 +155,7 @@ public class AnthropicBuilder implements ChatModelBuilder {
     }
 
     @Override
-    public ChatLanguageModel build() {
+    public ChatModel build() {
         return builder.build();
     }
 }

--- a/src/main/java/io/github/jeddict/ai/lang/impl/AnthropicStreamingBuilder.java
+++ b/src/main/java/io/github/jeddict/ai/lang/impl/AnthropicStreamingBuilder.java
@@ -16,7 +16,7 @@
 package io.github.jeddict.ai.lang.impl;
 
 import dev.langchain4j.model.anthropic.AnthropicStreamingChatModel;
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import io.github.jeddict.ai.lang.ChatModelStreamingBuilder;
 import java.time.Duration;
 import java.util.Map;
@@ -74,13 +74,7 @@ public class AnthropicStreamingBuilder implements ChatModelStreamingBuilder {
         builder.topP(topP);
         return this;
     }
-
-    @Override
-    public ChatModelStreamingBuilder maxRetries(final Integer maxRetries) {
-        //NOOP
-        return this;
-    }
-
+    
     @Override
     public ChatModelStreamingBuilder maxOutputTokens(final Integer maxOutputTokens) {
         //NOOP
@@ -155,7 +149,7 @@ public class AnthropicStreamingBuilder implements ChatModelStreamingBuilder {
     }
 
     @Override
-    public StreamingChatLanguageModel build() {
+    public StreamingChatModel build() {
         return builder.build();
     }
 }

--- a/src/main/java/io/github/jeddict/ai/lang/impl/GoogleBuilder.java
+++ b/src/main/java/io/github/jeddict/ai/lang/impl/GoogleBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.github.jeddict.ai.lang.impl;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel;
 import io.github.jeddict.ai.lang.ChatModelBuilder;
 import java.time.Duration;
@@ -154,7 +154,7 @@ public class GoogleBuilder implements ChatModelBuilder {
     }
 
     @Override
-    public ChatLanguageModel build() {
+    public ChatModel build() {
         return builder.build();
     }
 }

--- a/src/main/java/io/github/jeddict/ai/lang/impl/GoogleStreamingBuilder.java
+++ b/src/main/java/io/github/jeddict/ai/lang/impl/GoogleStreamingBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.github.jeddict.ai.lang.impl;
 
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.googleai.GoogleAiGeminiStreamingChatModel;
 import io.github.jeddict.ai.lang.ChatModelStreamingBuilder;
 import java.time.Duration;
@@ -72,12 +72,6 @@ public class GoogleStreamingBuilder implements ChatModelStreamingBuilder {
     @Override
     public ChatModelStreamingBuilder topP(final Double topP) {
         builder.topP(topP);
-        return this;
-    }
-
-    @Override
-    public ChatModelStreamingBuilder maxRetries(final Integer maxRetries) {
-        builder.maxRetries(maxRetries);
         return this;
     }
 
@@ -154,7 +148,7 @@ public class GoogleStreamingBuilder implements ChatModelStreamingBuilder {
     }
 
     @Override
-    public StreamingChatLanguageModel build() {
+    public StreamingChatModel build() {
         return builder.build();
     }
 

--- a/src/main/java/io/github/jeddict/ai/lang/impl/LMStudioBuilder.java
+++ b/src/main/java/io/github/jeddict/ai/lang/impl/LMStudioBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.github.jeddict.ai.lang.impl;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import io.github.jeddict.ai.lang.ChatModelBuilder;
 import io.github.jeddict.ai.models.LMStudioChatModel;
 import java.time.Duration;
@@ -155,7 +155,7 @@ public class LMStudioBuilder implements ChatModelBuilder {
     }
 
     @Override
-    public ChatLanguageModel build() {
+    public ChatModel build() {
         return builder.build();
     }
 }

--- a/src/main/java/io/github/jeddict/ai/lang/impl/LocalAiBuilder.java
+++ b/src/main/java/io/github/jeddict/ai/lang/impl/LocalAiBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.github.jeddict.ai.lang.impl;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.localai.LocalAiChatModel;
 import io.github.jeddict.ai.lang.ChatModelBuilder;
 import java.time.Duration;
@@ -155,7 +155,7 @@ public class LocalAiBuilder implements ChatModelBuilder {
     }
 
     @Override
-    public ChatLanguageModel build() {
+    public ChatModel build() {
         return builder.build();
     }
 }

--- a/src/main/java/io/github/jeddict/ai/lang/impl/LocalAiStreamingBuilder.java
+++ b/src/main/java/io/github/jeddict/ai/lang/impl/LocalAiStreamingBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.github.jeddict.ai.lang.impl;
 
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.localai.LocalAiStreamingChatModel;
 import io.github.jeddict.ai.lang.ChatModelStreamingBuilder;
 import java.time.Duration;
@@ -72,12 +72,6 @@ public class LocalAiStreamingBuilder implements ChatModelStreamingBuilder {
     @Override
     public ChatModelStreamingBuilder topP(final Double topP) {
         builder.topP(topP);
-        return this;
-    }
-
-    @Override
-    public ChatModelStreamingBuilder maxRetries(final Integer maxRetries) {
-        //NOOP
         return this;
     }
 
@@ -153,7 +147,7 @@ public class LocalAiStreamingBuilder implements ChatModelStreamingBuilder {
     }
 
     @Override
-    public StreamingChatLanguageModel build() {
+    public StreamingChatModel build() {
         return builder.build();
     }
 }

--- a/src/main/java/io/github/jeddict/ai/lang/impl/MistralBuilder.java
+++ b/src/main/java/io/github/jeddict/ai/lang/impl/MistralBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.github.jeddict.ai.lang.impl;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.mistralai.MistralAiChatModel;
 import io.github.jeddict.ai.lang.ChatModelBuilder;
 import java.time.Duration;
@@ -155,7 +155,7 @@ public class MistralBuilder implements ChatModelBuilder {
     }
 
     @Override
-    public ChatLanguageModel build() {
+    public ChatModel build() {
         return builder.build();
     }
 }

--- a/src/main/java/io/github/jeddict/ai/lang/impl/MistralStreamingBuilder.java
+++ b/src/main/java/io/github/jeddict/ai/lang/impl/MistralStreamingBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.github.jeddict.ai.lang.impl;
 
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.mistralai.MistralAiStreamingChatModel;
 import io.github.jeddict.ai.lang.ChatModelStreamingBuilder;
 import java.time.Duration;
@@ -72,12 +72,6 @@ public class MistralStreamingBuilder implements ChatModelStreamingBuilder {
     @Override
     public ChatModelStreamingBuilder topP(final Double topP) {
         builder.topP(topP);
-        return this;
-    }
-
-    @Override
-    public ChatModelStreamingBuilder maxRetries(final Integer maxRetries) {
-        //NOOP
         return this;
     }
 
@@ -155,7 +149,7 @@ public class MistralStreamingBuilder implements ChatModelStreamingBuilder {
     }
 
     @Override
-    public StreamingChatLanguageModel build() {
+    public StreamingChatModel build() {
         return builder.build();
     }
 }

--- a/src/main/java/io/github/jeddict/ai/lang/impl/OllamaBuilder.java
+++ b/src/main/java/io/github/jeddict/ai/lang/impl/OllamaBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.github.jeddict.ai.lang.impl;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.ollama.OllamaChatModel;
 import io.github.jeddict.ai.lang.ChatModelBuilder;
 import java.time.Duration;
@@ -155,7 +155,7 @@ public class OllamaBuilder implements ChatModelBuilder {
     }
 
     @Override
-    public ChatLanguageModel build() {
+    public ChatModel build() {
         return builder.build();
     }
 }

--- a/src/main/java/io/github/jeddict/ai/lang/impl/OllamaStreamingBuilder.java
+++ b/src/main/java/io/github/jeddict/ai/lang/impl/OllamaStreamingBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.github.jeddict.ai.lang.impl;
 
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.ollama.OllamaStreamingChatModel;
 import io.github.jeddict.ai.lang.ChatModelStreamingBuilder;
 import java.time.Duration;
@@ -72,12 +72,6 @@ public class OllamaStreamingBuilder implements ChatModelStreamingBuilder {
     @Override
     public ChatModelStreamingBuilder topP(final Double topP) {
         builder.topP(topP);
-        return this;
-    }
-
-    @Override
-    public ChatModelStreamingBuilder maxRetries(final Integer maxRetries) {
-        //NOOP
         return this;
     }
 
@@ -155,7 +149,7 @@ public class OllamaStreamingBuilder implements ChatModelStreamingBuilder {
     }
 
     @Override
-    public StreamingChatLanguageModel build() {
+    public StreamingChatModel build() {
         return builder.build();
     }
 }

--- a/src/main/java/io/github/jeddict/ai/lang/impl/OpenAiBuilder.java
+++ b/src/main/java/io/github/jeddict/ai/lang/impl/OpenAiBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.github.jeddict.ai.lang.impl;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import io.github.jeddict.ai.lang.ChatModelBuilder;
 import java.time.Duration;
@@ -155,7 +155,7 @@ public class OpenAiBuilder implements ChatModelBuilder {
     }
 
     @Override
-    public ChatLanguageModel build() {
+    public ChatModel build() {
         return builder.build();
     }
 }

--- a/src/main/java/io/github/jeddict/ai/lang/impl/OpenAiStreamingBuilder.java
+++ b/src/main/java/io/github/jeddict/ai/lang/impl/OpenAiStreamingBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.github.jeddict.ai.lang.impl;
 
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
 import io.github.jeddict.ai.lang.ChatModelStreamingBuilder;
 import java.time.Duration;
@@ -72,12 +72,6 @@ public class OpenAiStreamingBuilder implements ChatModelStreamingBuilder {
     @Override
     public ChatModelStreamingBuilder topP(final Double topP) {
         builder.topP(topP);
-        return this;
-    }
-
-    @Override
-    public ChatModelStreamingBuilder maxRetries(final Integer maxRetries) {
-        //NOOP
         return this;
     }
 
@@ -155,7 +149,7 @@ public class OpenAiStreamingBuilder implements ChatModelStreamingBuilder {
     }
 
     @Override
-    public StreamingChatLanguageModel build() {
+    public StreamingChatModel build() {
         return builder.build();
     }
 

--- a/src/main/java/io/github/jeddict/ai/models/LMStudioChatModel.java
+++ b/src/main/java/io/github/jeddict/ai/models/LMStudioChatModel.java
@@ -15,28 +15,27 @@
  */
 package io.github.jeddict.ai.models;
 
-import dev.ai4j.openai4j.OpenAiClient;
-import dev.ai4j.openai4j.chat.ChatCompletionRequest;
-import dev.ai4j.openai4j.chat.ChatCompletionResponse;
-import dev.ai4j.openai4j.shared.Usage;
-import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.ChatMessage;
+
+
 import static dev.langchain4j.internal.RetryUtils.withRetry;
+import dev.langchain4j.model.chat.ChatModel;
+
 import static dev.langchain4j.internal.ValidationUtils.ensureNotBlank;
-import dev.langchain4j.model.chat.ChatLanguageModel;
-import static dev.langchain4j.model.openai.InternalOpenAiHelper.aiMessageFrom;
-import static dev.langchain4j.model.openai.InternalOpenAiHelper.finishReasonFrom;
-import static dev.langchain4j.model.openai.InternalOpenAiHelper.toFunctions;
-import static dev.langchain4j.model.openai.InternalOpenAiHelper.toOpenAiMessages;
-import dev.langchain4j.model.output.Response;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.openai.internal.OpenAiClient;
+import static dev.langchain4j.model.openai.internal.OpenAiUtils.aiMessageFrom;
+import static dev.langchain4j.model.openai.internal.OpenAiUtils.finishReasonFrom;
+import dev.langchain4j.model.openai.internal.chat.ChatCompletionRequest;
+import dev.langchain4j.model.openai.internal.chat.ChatCompletionResponse;
+import dev.langchain4j.model.openai.internal.chat.UserMessage;
+import dev.langchain4j.model.openai.internal.shared.Usage;
 import dev.langchain4j.model.output.TokenUsage;
 import java.time.Duration;
 import static java.time.Duration.ofSeconds;
-import static java.util.Collections.singletonList;
-import java.util.List;
+import java.util.stream.Collectors;
 
-public class LMStudioChatModel implements ChatLanguageModel {
+public class LMStudioChatModel implements ChatModel {
 
     public static final String LMSTUDIO_MODEL_URL = "http://localhost:1234/v1/";
     private final OpenAiClient client;
@@ -61,12 +60,9 @@ public class LMStudioChatModel implements ChatLanguageModel {
         maxRetries = maxRetries == null ? 3 : maxRetries;
 
         this.client = OpenAiClient.builder()
-                .openAiApiKey("ignored")
                 .baseUrl(ensureNotBlank(baseUrl, "baseUrl"))
-                .callTimeout(timeout)
                 .connectTimeout(timeout)
                 .readTimeout(timeout)
-                .writeTimeout(timeout)
                 .logRequests(logRequests)
                 .logResponses(logResponses)
                 .build();
@@ -144,48 +140,25 @@ public class LMStudioChatModel implements ChatLanguageModel {
     }
 
     @Override
-    public Response<AiMessage> generate(List<ChatMessage> messages) {
-        return generate(messages, null, null);
-    }
-
-    @Override
-    public Response<AiMessage> generate(List<ChatMessage> messages, List<ToolSpecification> toolSpecifications) {
-        return generate(messages, toolSpecifications, null);
-    }
-
-    @Override
-    public Response<AiMessage> generate(List<ChatMessage> messages, ToolSpecification toolSpecification) {
-        return generate(messages, singletonList(toolSpecification), toolSpecification);
-    }
-
-    private Response<AiMessage> generate(List<ChatMessage> messages,
-            List<ToolSpecification> toolSpecifications,
-            ToolSpecification toolThatMustBeExecuted
-    ) {
-        ChatCompletionRequest.Builder requestBuilder = ChatCompletionRequest.builder()
+    public ChatResponse doChat(ChatRequest request) {
+        ChatCompletionRequest completionRequest = ChatCompletionRequest.builder()
                 .model(modelName)
-                .messages(toOpenAiMessages(messages))
+                .messages(request.messages().stream()
+                        .map(msg -> UserMessage.from(msg.toString())) // Convert Langchain4j Message to OpenAI ChatMessage
+                        .collect(Collectors.toList()))
                 .temperature(temperature)
                 .topP(topP)
-                .maxTokens(maxTokens);
+                .maxTokens(maxTokens)
+                .build();
 
-        if (toolSpecifications != null && !toolSpecifications.isEmpty()) {
-            requestBuilder.functions(toFunctions(toolSpecifications));
-        }
-        if (toolThatMustBeExecuted != null) {
-            requestBuilder.functionCall(toolThatMustBeExecuted.name());
-        }
-
-        ChatCompletionRequest request = requestBuilder.build();
-
-        ChatCompletionResponse response = withRetry(() -> client.chatCompletion(request).execute(), maxRetries);
+        ChatCompletionResponse response = withRetry(() -> client.chatCompletion(completionRequest).execute(), maxRetries);
 
         Usage usage = response.usage();
 
-        return Response.from(
-                aiMessageFrom(response),
-                new TokenUsage(usage.promptTokens(), usage.completionTokens()),
-                finishReasonFrom(response.choices().get(0).finishReason())
-        );
+        return ChatResponse.builder()
+            .aiMessage(aiMessageFrom(response))
+            .tokenUsage(new TokenUsage(usage.promptTokens(), usage.completionTokens()))
+            .finishReason(finishReasonFrom(response.choices().get(0).finishReason()))
+            .build();
     }
 }


### PR DESCRIPTION
Upgraded LangChain4j dependencies in pom.xml to version 1.3.0 (or 1.3.0-beta9 for local-ai) and added langchain4j-http-client-jdk. Although the effort to adapt the current codebase to langchain 1.3 was quite minimal, I think it is needed as langchain has done major architectural changes in 1.x and having the latest version is a much more solid basis for further improvements.

This upgrade required significant refactoring to adapt to the new LangChain4j API, including:
   - Migrating from ChatLanguageModel to ChatModel and StreamingChatLanguageModel to StreamingChatModel.
   - Updating chat generation methods from generate to chat.
   - Adjusting JeddictStreamHandler to use StreamingChatResponseHandler and its new methods
     (onPartialResponse, onCompleteResponse).
   - Modifying error handling for chat model responses.
   - Refactoring maxRetries handling in chat model builders.
   - Updating LMStudioChatModel to align with the new ChatModel interface.

PLEASE NOTE: LMStudioChatModel required some more work, which I am still not able to test because LMStudio is not really working on my PC. I'll be happy to improve or do more changes as reqquired.
