### PR TITLE
feat: Save and restore AI query pane state on chat close/open

### DIFF
--- a/src/main/java/io/github/jeddict/ai/components/AssistantChat.java
+++ b/src/main/java/io/github/jeddict/ai/components/AssistantChat.java
@@ -21,10 +21,14 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import io.github.jeddict.ai.agent.AssistantAction;
 import static io.github.jeddict.ai.classpath.JeddictQueryCompletionQuery.JEDDICT_EDITOR_CALLBACK;
+import static io.github.jeddict.ai.components.QueryPane.createIconButton;
+import static io.github.jeddict.ai.components.QueryPane.createStyledComboBox;
 import io.github.jeddict.ai.components.mermaid.MermaidPane;
 import io.github.jeddict.ai.response.Block;
 import io.github.jeddict.ai.review.Review;
+import static io.github.jeddict.ai.settings.GenAIProvider.getModelsByProvider;
 import io.github.jeddict.ai.settings.PreferencesManager;
 import io.github.jeddict.ai.util.ColorUtil;
 import static io.github.jeddict.ai.util.DiffUtil.diffAction;
@@ -37,10 +41,18 @@ import static io.github.jeddict.ai.util.EditorUtil.getExtension;
 import static io.github.jeddict.ai.util.EditorUtil.getFontFromMimeType;
 import static io.github.jeddict.ai.util.EditorUtil.getTextColorFromMimeType;
 import static io.github.jeddict.ai.util.EditorUtil.isSuitableForWebAppDirectory;
+import static io.github.jeddict.ai.util.Icons.ICON_ATTACH;
 import static io.github.jeddict.ai.util.Icons.ICON_CANCEL;
+import static io.github.jeddict.ai.util.Icons.ICON_CONTEXT;
 import static io.github.jeddict.ai.util.Icons.ICON_COPY;
 import static io.github.jeddict.ai.util.Icons.ICON_EDIT;
+import static io.github.jeddict.ai.util.Icons.ICON_NEW_CHAT;
+import static io.github.jeddict.ai.util.Icons.ICON_NEXT;
+import static io.github.jeddict.ai.util.Icons.ICON_PREV;
 import static io.github.jeddict.ai.util.Icons.ICON_SEND;
+import static io.github.jeddict.ai.util.Icons.ICON_SETTINGS;
+import static io.github.jeddict.ai.util.Icons.ICON_STATS;
+import static io.github.jeddict.ai.util.Icons.ICON_WEB;
 import io.github.jeddict.ai.util.Labels;
 import static io.github.jeddict.ai.util.MimeUtil.JAVA_MIME;
 import static io.github.jeddict.ai.util.MimeUtil.MIME_PLAIN_TEXT;
@@ -49,10 +61,16 @@ import static io.github.jeddict.ai.util.StringUtil.convertToCapitalized;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Desktop;
+import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.File;
@@ -72,10 +90,13 @@ import java.util.prefs.Preferences;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
+import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
+import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JEditorPane;
 import javax.swing.JFileChooser;
@@ -84,8 +105,12 @@ import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
+import javax.swing.KeyStroke;
+import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.Timer;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.text.Document;
@@ -93,9 +118,14 @@ import javax.swing.text.EditorKit;
 import javax.swing.text.JTextComponent;
 import javax.swing.text.StyledDocument;
 import org.netbeans.api.editor.EditorRegistry;
+import org.netbeans.api.options.OptionsDisplayer;
 import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.modules.editor.NbEditorUtilities;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
 import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
 import org.openide.windows.TopComponent;
 
@@ -103,21 +133,37 @@ import org.openide.windows.TopComponent;
  *
  * @author Shiwani Gupta
  */
-public class AssistantChat extends TopComponent {
+public abstract class AssistantChat extends TopComponent {
 
     private List<Review> reviews;
     public static final ImageIcon icon = new ImageIcon(AssistantChat.class.getResource("/icons/logo16.png"));
     public static final ImageIcon logoIcon = new ImageIcon(AssistantChat.class.getResource("/icons/logo28.png"));
 
-    public static final String PREFERENCE_KEY = "AssistantTopComponentOpen";
+    private static final String QUESTION_KEY = "QUESTION";
     private final JPanel parentPanel;
-    private final Project project;
+    private Project project;
 
     private final Map<JEditorPane, JPopupMenu> menus = new HashMap<>();
     private final Map<JEditorPane, List<JMenuItem>> menuItems = new HashMap<>();
     private final Map<JEditorPane, List<JMenuItem>> submenuItems = new HashMap<>();
     private String type = "java";
     private static final PreferencesManager pm = PreferencesManager.getInstance();
+
+    private Timer timer;
+
+    // top query pane
+    private JButton copyButton, editButton, saveButton, cancelButton;
+    private JEditorPane queryPane;
+
+    // bottom question pane
+    private JPanel filePanel;
+    private MessageContextComponentAdapter filePanelAdapter;
+    private ComponentAdapter buttonPanelAdapter;
+    private JComboBox<String> models;
+    private JComboBox<AssistantAction> actionComboBox;
+    private JButton prevButton, nextButton, openInBrowserButton, submitButton;
+    private JEditorPane questionPane;
+    private JScrollPane questionScrollPane;
 
     public AssistantChat(String name, String type, Project project) {
         setName(name);
@@ -132,6 +178,408 @@ public class AssistantChat extends TopComponent {
         parentPanel.setLayout(new BoxLayout(parentPanel, BoxLayout.Y_AXIS));
         add(parentPanel, BorderLayout.CENTER);
     }
+    
+    public abstract void onChatReset();
+
+    public abstract void onSubmit();
+
+    public abstract void onPrev();
+
+    public abstract void onNext();
+
+    public abstract void onSessionContext();
+
+    public abstract void addFileTab(FileObject file);
+
+    public abstract void clearFileTab();
+
+
+    public JEditorPane getQuestionPane() {
+        return questionPane;
+    }
+
+    public void updateButtons(Boolean prevButtonVisible, Boolean nextButtonVisible) {
+        // TODO: to be reviewed once all agents will use buit-in memory
+        prevButton.setVisible(prevButtonVisible);
+        nextButton.setVisible(nextButtonVisible);
+        openInBrowserButton.setVisible(getAllEditorCount() > 0);
+    }
+
+    public void startLoading() {
+        final String[] spinnerFrames = {"◐", "◓", "◑", "◒"};
+        final int[] frameIndex = {0};
+        timer = new Timer(200, e -> {
+            submitButton.setText(spinnerFrames[frameIndex[0]]);
+            frameIndex[0] = (frameIndex[0] + 1) % spinnerFrames.length;
+        });
+        timer.start();
+    }
+
+    public void stopLoading() {
+        timer.stop();
+    }
+
+   public String getModelName() {
+        String modelName = (String) models.getSelectedItem();
+        if (modelName == null || modelName.isEmpty()) {
+            return pm.getModel();
+        }
+        return modelName;
+    }
+
+    public void buttonPanelResized() {
+         buttonPanelAdapter.componentResized(null);
+    }
+
+    public boolean isAgentEnabled() {
+        return actionComboBox.getSelectedItem() == AssistantAction.BUILD;
+    }
+
+    public JPanel createBottomPanel(String type, String fileName, Consumer<String> action) {
+        JPanel bottomPanel = new JPanel(new BorderLayout());
+
+        Color backgroundColor = getBackgroundColorFromMimeType(MIME_PLAIN_TEXT);
+        filePanel = new JPanel();
+        filePanelAdapter = new MessageContextComponentAdapter(filePanel);
+        filePanel.setLayout(new FlowLayout(FlowLayout.LEFT));
+        filePanel.setBackground(backgroundColor);
+        filePanel.setBorder(BorderFactory.createEmptyBorder());
+        filePanel.addComponentListener(filePanelAdapter);
+
+        JPanel buttonPanel = new JPanel(new BorderLayout());
+        buttonPanel.setBackground(backgroundColor);
+        buttonPanel.setBorder(BorderFactory.createEmptyBorder());
+
+        JPanel rightButtonPanel = new JPanel();
+        rightButtonPanel.setLayout(new FlowLayout(FlowLayout.RIGHT, 8, 1));
+        rightButtonPanel.setBackground(backgroundColor);
+        rightButtonPanel.setBorder(BorderFactory.createEmptyBorder());
+        buttonPanel.add(rightButtonPanel, BorderLayout.EAST);
+
+        JPanel leftButtonPanel = new JPanel();
+        leftButtonPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 8, 1));
+        leftButtonPanel.setBackground(backgroundColor);
+        leftButtonPanel.setBorder(BorderFactory.createEmptyBorder());
+        buttonPanel.add(leftButtonPanel, BorderLayout.WEST);
+
+        prevButton = createIconButton(Labels.PREV, ICON_PREV);
+        prevButton.setToolTipText("Previous Chat");
+        leftButtonPanel.add(prevButton);
+
+        nextButton = createIconButton(Labels.NEXT, ICON_NEXT);
+        nextButton.setToolTipText("Next Chat");
+        leftButtonPanel.add(nextButton);
+
+        openInBrowserButton = createIconButton(Labels.VIEW, ICON_WEB);
+        openInBrowserButton.setToolTipText("Open in Browser");
+        openInBrowserButton.setVisible(getAllEditorCount() > 0);
+        leftButtonPanel.add(openInBrowserButton);
+
+        Set<String> modelsByProvider = getModelsByProvider(pm.getProvider());
+
+        modelsByProvider.add(pm.getModelName());
+        models = createStyledComboBox(modelsByProvider.toArray(new String[0]));
+        models.setSelectedItem(pm.getChatModel() != null ? pm.getChatModel() : pm.getModel());
+        models.setToolTipText("AI Models");
+        models.addActionListener(e -> {
+            String selectedModel = (String) models.getSelectedItem();
+            if (selectedModel != null) {
+                pm.setChatModel(selectedModel);
+            }
+        });
+        leftButtonPanel.add(models);
+
+        AssistantAction[] options = AssistantAction.values();
+        actionComboBox = createStyledComboBox(options);
+        String lastAction = pm.getAssistantAction();
+        if (lastAction != null) {
+            try {
+                actionComboBox.setSelectedItem(AssistantAction.valueOf(lastAction));
+            } catch (IllegalArgumentException ex) {
+                actionComboBox.setSelectedItem(AssistantAction.ASK);
+            }
+        } else {
+            actionComboBox.setSelectedItem(AssistantAction.ASK);
+        }
+        actionComboBox.setToolTipText("<html><b>Chat</b> – for general queries<br><b>Agent</b> – for file/project generation actions</html>");
+        actionComboBox.addActionListener(e -> {
+            AssistantAction selectedAction = (AssistantAction) actionComboBox.getSelectedItem();
+            if (selectedAction == AssistantAction.BUILD) {
+                if (this.project == null) {
+                    Project[] openProjects = org.netbeans.api.project.ui.OpenProjects.getDefault().getOpenProjects();
+                    if (openProjects.length == 1) {
+                        project = openProjects[0];
+                        DialogDisplayer.getDefault().notify(
+                                new NotifyDescriptor.Message(
+                                        "Connected chat to project: " + ProjectUtils.getInformation(project).getDisplayName(),
+                                        NotifyDescriptor.INFORMATION_MESSAGE
+                                )
+                        );
+                    } else if (openProjects.length > 1) {
+                        JComboBox<Project> projectComboBox = new JComboBox<>(openProjects);
+                        projectComboBox.setRenderer(new javax.swing.ListCellRenderer<>() {
+                            private final javax.swing.DefaultListCellRenderer defaultRenderer = new javax.swing.DefaultListCellRenderer();
+
+                            @Override
+                            public java.awt.Component getListCellRendererComponent(javax.swing.JList<? extends Project> list, Project value, int index, boolean isSelected, boolean cellHasFocus) {
+                                String displayName = (value == null) ? "" : ProjectUtils.getInformation(value).getDisplayName();
+                                return defaultRenderer.getListCellRendererComponent(list, displayName, index, isSelected, cellHasFocus);
+                            }
+                        });
+                        NotifyDescriptor descriptor = new NotifyDescriptor(
+                                projectComboBox,
+                                "Select Project for AI Agent Mode",
+                                NotifyDescriptor.OK_CANCEL_OPTION,
+                                NotifyDescriptor.QUESTION_MESSAGE,
+                                null,
+                                NotifyDescriptor.OK_OPTION
+                        );
+                        Object dialogResult = DialogDisplayer.getDefault().notify(descriptor);
+                        if (NotifyDescriptor.OK_OPTION.equals(dialogResult)) {
+                            Project selectedProject = (Project) projectComboBox.getSelectedItem();
+                            if (selectedProject != null) {
+                                project = selectedProject;
+                                DialogDisplayer.getDefault().notify(
+                                        new NotifyDescriptor.Message(
+                                                "Connected chat to project: " + ProjectUtils.getInformation(project).getDisplayName(),
+                                                NotifyDescriptor.INFORMATION_MESSAGE
+                                        )
+                                );
+                            } else {
+                                actionComboBox.setSelectedItem(AssistantAction.ASK);
+                            }
+                        } else {
+                            actionComboBox.setSelectedItem(AssistantAction.ASK);
+                        }
+                    } else {
+                        NotifyDescriptor.Message msg = new NotifyDescriptor.Message(
+                                "To use AI agent mode, connect chat to any project by dropping any source file on chat window or start new chat from project/package/source file context.",
+                                NotifyDescriptor.WARNING_MESSAGE
+                        );
+                        DialogDisplayer.getDefault().notify(msg);
+                        actionComboBox.setSelectedItem(AssistantAction.ASK);
+                    }
+                }
+            }
+            selectedAction = (AssistantAction) actionComboBox.getSelectedItem();
+            if (selectedAction != null) {
+                pm.setAssistantAction(selectedAction.name());
+            }
+        });
+        leftButtonPanel.add(actionComboBox);
+
+        JButton showChartsButton = createIconButton(Labels.STATS, ICON_STATS);
+        showChartsButton.setToolTipText("Show Token Usage Charts");
+        rightButtonPanel.add(showChartsButton);
+        showChartsButton.addActionListener(e -> {
+            TokenUsageChartDialog.showDialog(SwingUtilities.getWindowAncestor(showChartsButton));
+        });
+
+        JButton optionsButton = createIconButton(Labels.SETTINGS, ICON_SETTINGS);
+        optionsButton.setToolTipText("Open Jeddict AI Assistant Settings");
+        optionsButton.addActionListener(e -> OptionsDisplayer.getDefault().open("JeddictAIAssistant"));
+        rightButtonPanel.add(optionsButton);
+
+        JButton messageContextButton = createIconButton(Labels.MESSAGE_CONTEXT, ICON_ATTACH);
+        messageContextButton.setToolTipText("Attach a file to current message context");
+        rightButtonPanel.add(messageContextButton);
+
+        JButton sessionContextButton = createIconButton(Labels.SESSION_CONTEXT, ICON_CONTEXT);
+        sessionContextButton.setToolTipText("View detailed context of the current chat session context.");
+        sessionContextButton.addActionListener(e -> onSessionContext());
+        rightButtonPanel.add(sessionContextButton);
+
+        JButton newChatButton = createIconButton(Labels.NEW_CHAT, ICON_NEW_CHAT);
+        newChatButton.setToolTipText("Start a new chat");
+        leftButtonPanel.add(newChatButton);
+
+        submitButton = createIconButton(Labels.SEND, ICON_SEND);
+        submitButton.setToolTipText("Ask a question");
+        rightButtonPanel.add(submitButton);
+
+        buttonPanelAdapter = new ComponentAdapter() {
+            boolean showOnlyIcons = false;
+
+            @Override
+            public void componentResized(ComponentEvent e) {
+                double totalButtonWidth = leftButtonPanel.getPreferredSize().width
+                        + rightButtonPanel.getPreferredSize().width;
+                if (showOnlyIcons) {
+                    totalButtonWidth = totalButtonWidth * 2;
+                }
+
+                int availableWidth = buttonPanel.getWidth();
+                showOnlyIcons = availableWidth < totalButtonWidth;
+
+                updateButton(prevButton, showOnlyIcons, ICON_PREV, Labels.PREV + " " + ICON_PREV);
+                updateButton(nextButton, showOnlyIcons, ICON_NEXT, Labels.NEXT + " " + ICON_NEXT);
+                updateButton(openInBrowserButton, showOnlyIcons, ICON_WEB, Labels.VIEW + " " + ICON_WEB);
+//                updateButton(copyButton, showOnlyIcons, ICON_COPY, Labels.COPY + " " + ICON_COPY);
+//                updateButton(saveButton, showOnlyIcons, ICON_SAVE, Labels.SAVE + " " + ICON_SAVE);
+//                updateButton(saveToEditorButton, showOnlyIcons, ICON_UPDATE, Labels.UPDATE + " " + ICON_UPDATE);
+                updateButton(newChatButton, showOnlyIcons, ICON_NEW_CHAT, Labels.NEW_CHAT + " " + ICON_NEW_CHAT);
+                updateButton(showChartsButton, showOnlyIcons, ICON_STATS, Labels.STATS + " " + ICON_STATS);
+                updateButton(optionsButton, showOnlyIcons, ICON_SETTINGS, Labels.SETTINGS + " " + ICON_SETTINGS);
+                updateButton(messageContextButton, showOnlyIcons, ICON_ATTACH, Labels.MESSAGE_CONTEXT + " " + ICON_ATTACH);
+                updateButton(sessionContextButton, showOnlyIcons, ICON_CONTEXT, Labels.SESSION_CONTEXT + " " + ICON_CONTEXT);
+                updateButton(submitButton, showOnlyIcons, ICON_SEND, Labels.SEND + " " + ICON_SEND);
+                updateCombobox(models, showOnlyIcons);
+                updateCombobox(actionComboBox, showOnlyIcons);
+                updateUserPaneButtons(showOnlyIcons);
+
+            }
+
+            private void updateButton(JButton button, boolean iconOnly, String iconText, String fullText) {
+                button.setText(iconOnly ? iconText : fullText);
+            }
+
+            private <T> void updateCombobox(JComboBox<T> comboBox, boolean iconOnly) {
+                comboBox.putClientProperty("minimal", iconOnly);
+            }
+        };
+        buttonPanel.addComponentListener(buttonPanelAdapter);
+
+        questionPane = new JEditorPane();
+        questionPane.setEditorKit(createEditorKit("text/x-" + (type == null ? "java" : type)));
+        questionPane.putClientProperty("AI_QUERY_EDITOR", Boolean.TRUE);
+
+        Document doc = questionPane.getDocument();
+        doc.putProperty(JEDDICT_EDITOR_CALLBACK, (Consumer<FileObject>) this::addFileTab);
+
+        questionScrollPane = new JScrollPane(questionPane);
+        questionScrollPane.setBorder(BorderFactory.createEmptyBorder());
+        questionScrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+        questionScrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        Color bgColor = getBackgroundColorFromMimeType(MIME_PLAIN_TEXT);
+        boolean isDark = ColorUtil.isDarkColor(bgColor);
+        if (isDark) {
+            questionScrollPane.getViewport().setBackground(Color.DARK_GRAY);
+            questionScrollPane.getVerticalScrollBar().setUI(new CustomScrollBarUI());
+            questionScrollPane.getHorizontalScrollBar().setUI(new CustomScrollBarUI());
+        }
+        questionPane.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                updateHeight();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                updateHeight();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                updateHeight();
+            }
+        });
+
+        newChatButton.addActionListener(e -> {
+            this.clear();
+            this.repaint();
+            questionPane.setText("");
+            clearFileTab();
+            onChatReset();
+
+        });
+
+        openInBrowserButton.addActionListener(e -> {
+            try {
+                File latestTempFile = File.createTempFile("gen-ai", ".html");
+                latestTempFile.deleteOnExit();
+                try (FileWriter writer = new FileWriter(latestTempFile)) {
+                    writer.write(this.getAllEditorText());
+                }
+                if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+                    Desktop.getDesktop().browse(latestTempFile.toURI());
+                }
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
+        });
+
+        submitButton.setAction(new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent ae) {
+                onSubmit();
+
+            }
+        });
+
+        prevButton.addActionListener(e -> {
+            onPrev();
+        });
+
+        nextButton.addActionListener(e -> {
+            onNext();
+        });
+
+        messageContextButton.addActionListener(e -> {
+            JFileChooser fileChooser = new JFileChooser(pm.getLastBrowseDirectory());
+            int result = fileChooser.showOpenDialog(bottomPanel);
+            if (result == JFileChooser.APPROVE_OPTION) {
+                File selectedFile = fileChooser.getSelectedFile();
+                pm.setLastBrowseDirectory(selectedFile.getParent());
+                addFileTab(FileUtil.toFileObject(selectedFile));
+            }
+        });
+
+        FileTransferHandler.register(bottomPanel, this::addFileTab);
+        FileTransferHandler.register(questionPane, this::addFileTab);
+
+        //
+        // intercept shortkeys to submit the prompt
+        //
+        final String actionKey = "submit-prompt";
+
+        String shortcut = pm.getSubmitShortcut(); // e.g. "Ctrl + Enter", "Enter", "Shift + Enter", "Alt + Enter"
+
+        javax.swing.KeyStroke submitKey;
+        switch (shortcut) {
+            case "Enter":
+                submitKey = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0);
+                break;
+            case "Shift + Enter":
+                submitKey = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, KeyEvent.SHIFT_DOWN_MASK);
+                break;
+            default: // "Ctrl + Enter"
+                submitKey = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, KeyEvent.CTRL_DOWN_MASK);
+        }
+
+        final javax.swing.InputMap inputMap = questionPane.getInputMap(JComponent.WHEN_FOCUSED);
+        final javax.swing.ActionMap actionMap = questionPane.getActionMap();
+
+        inputMap.put(submitKey, actionKey);
+        actionMap.put(actionKey, submitButton.getAction());
+
+        // ---
+        bottomPanel.setLayout(new BoxLayout(bottomPanel, BoxLayout.Y_AXIS));
+        bottomPanel.add(filePanel);
+        bottomPanel.add(Box.createVerticalStrut(0));
+        bottomPanel.add(questionScrollPane);
+        bottomPanel.add(Box.createVerticalStrut(0));
+        bottomPanel.add(buttonPanel);
+
+        return bottomPanel;
+    }
+
+    public void updateHeight() {
+        int lineHeight = questionPane.getFontMetrics(questionPane.getFont()).getHeight();
+        String text = questionPane.getText().trim();
+        int preferredHeight;
+        int linePadding = 5;
+        if (text.isEmpty()) {
+            preferredHeight = lineHeight * 3 + linePadding;
+        } else {
+            preferredHeight = questionPane.getPreferredSize().height;
+            preferredHeight = Math.max(lineHeight * 3 + linePadding,
+                    Math.min(preferredHeight, lineHeight * 12 + linePadding));
+        }
+
+        Dimension size = new Dimension(questionScrollPane.getWidth(), preferredHeight);
+        questionScrollPane.setPreferredSize(size);
+        questionScrollPane.revalidate();
+    }
 
     public void lastRemove() {
         parentPanel.remove(parentPanel.getComponentCount() - 1);
@@ -141,9 +589,6 @@ public class AssistantChat extends TopComponent {
         parentPanel.removeAll();
         menus.clear();
     }
-
-    private JButton copyButton, editButton, saveButton, cancelButton;
-    private JEditorPane queryPane;
 
     public void updateUserPaneButtons(boolean iconOnly) {
         if (copyButton != null) {
@@ -194,6 +639,25 @@ public class AssistantChat extends TopComponent {
             state.accept(false);
             queryPane.requestFocus();
         });
+    }
+  
+    public void clearFiles() {
+        filePanel.removeAll();
+        refreshFilePanel();
+        filePanel.revalidate();
+        filePanel.repaint();
+    }
+
+    public void addFile(FileObject file, Consumer<FileObject> onCloseCallback) {
+        FileTab fileTab = new FileTab(file, filePanel, onCloseCallback);
+        filePanel.add(fileTab);
+        refreshFilePanel();
+        filePanel.revalidate();
+        filePanel.repaint();
+    }
+
+    public void refreshFilePanel() {
+        filePanelAdapter.componentResized(null);
     }
 
     public JEditorPane createUserQueryPane(BiConsumer<String, Set<FileObject>> queryUpdate, String content, Set<FileObject> messageContext) {
@@ -279,8 +743,6 @@ public class AssistantChat extends TopComponent {
         return queryPane;
     }
 
-    private JPanel filePanel;
-    private MessageContextComponentAdapter filePanelAdapter;
 
     public JEditorPane createHtmlPane(String content) {
         JEditorPane editorPane = new JEditorPane();
@@ -332,7 +794,6 @@ public class AssistantChat extends TopComponent {
         return editorPane;
     }
 
-
     public JEditorPane createCodePane(String mimeType, Block content) {
         if (mimeType == null || mimeType.isBlank()) {
             mimeType = MIME_PLAIN_TEXT;
@@ -347,8 +808,8 @@ public class AssistantChat extends TopComponent {
         } else {
             editorPane = createInMemoryEditorCopy(mimeType);
         }
-        
-            editorPane.setText(content.getContent());
+
+        editorPane.setText(content.getContent());
         editorPane.getDocument().addDocumentListener(new DocumentListener() {
             @Override
             public void insertUpdate(DocumentEvent e) {
@@ -532,19 +993,16 @@ public class AssistantChat extends TopComponent {
     public void componentOpened() {
         super.componentOpened();
         Preferences prefs = Preferences.userNodeForPackage(this.getClass());
-        boolean shouldOpen = prefs.getBoolean(PREFERENCE_KEY, true);
-        if (!shouldOpen) {
-            this.close();
-        }
+        questionPane.setText(prefs.get(QUESTION_KEY, ""));
     }
 
     @Override
     public void componentClosed() {
         super.componentClosed();
         Preferences prefs = Preferences.userNodeForPackage(this.getClass());
-        prefs.putBoolean(PREFERENCE_KEY, false);
+        prefs.put(QUESTION_KEY, questionPane.getText());
     }
-
+    
     public JPanel getParentPanel() {
         return parentPanel;
     }

--- a/src/main/java/io/github/jeddict/ai/hints/AssistantChatManager.java
+++ b/src/main/java/io/github/jeddict/ai/hints/AssistantChatManager.java
@@ -15,7 +15,6 @@
  */
 package io.github.jeddict.ai.hints;
 
-import io.github.jeddict.ai.agent.AssistantAction;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
@@ -39,19 +38,12 @@ import io.github.jeddict.ai.agent.pair.DiffSpecialist;
 import io.github.jeddict.ai.agent.pair.PairProgrammer;
 import io.github.jeddict.ai.agent.pair.TechWriter;
 import io.github.jeddict.ai.agent.pair.TestSpecialist;
-import static io.github.jeddict.ai.classpath.JeddictQueryCompletionQuery.JEDDICT_EDITOR_CALLBACK;
 import io.github.jeddict.ai.completion.Action;
 import io.github.jeddict.ai.completion.SQLCompletion;
 import io.github.jeddict.ai.components.AssistantChat;
 import io.github.jeddict.ai.components.ContextDialog;
 import io.github.jeddict.ai.components.CustomScrollBarUI;
-import io.github.jeddict.ai.components.FileTab;
-import io.github.jeddict.ai.components.FileTransferHandler;
 import static io.github.jeddict.ai.components.MarkdownPane.getHtmlWrapWidth;
-import io.github.jeddict.ai.components.MessageContextComponentAdapter;
-import static io.github.jeddict.ai.components.QueryPane.createIconButton;
-import static io.github.jeddict.ai.components.QueryPane.createStyledComboBox;
-import io.github.jeddict.ai.components.TokenUsageChartDialog;
 import io.github.jeddict.ai.lang.JeddictBrain;
 import io.github.jeddict.ai.lang.JeddictBrainListener;
 import io.github.jeddict.ai.response.Block;
@@ -59,7 +51,6 @@ import io.github.jeddict.ai.response.Response;
 import io.github.jeddict.ai.review.Review;
 import static io.github.jeddict.ai.review.ReviewUtil.convertReviewsToHtml;
 import static io.github.jeddict.ai.review.ReviewUtil.parseReviewsFromYaml;
-import static io.github.jeddict.ai.settings.GenAIProvider.getModelsByProvider;
 import io.github.jeddict.ai.settings.PreferencesManager;
 import io.github.jeddict.ai.util.ColorUtil;
 import static io.github.jeddict.ai.util.ContextHelper.getFilesContextList;
@@ -67,36 +58,15 @@ import static io.github.jeddict.ai.util.ContextHelper.getImageFilesContext;
 import static io.github.jeddict.ai.util.ContextHelper.getProjectContext;
 import static io.github.jeddict.ai.util.ContextHelper.getTextFilesContext;
 import io.github.jeddict.ai.util.EditorUtil;
-import static io.github.jeddict.ai.util.EditorUtil.createEditorKit;
 import static io.github.jeddict.ai.util.EditorUtil.getBackgroundColorFromMimeType;
 import static io.github.jeddict.ai.util.EditorUtil.getHTMLContent;
-import static io.github.jeddict.ai.util.Icons.ICON_ATTACH;
-import static io.github.jeddict.ai.util.Icons.ICON_CONTEXT;
-import static io.github.jeddict.ai.util.Icons.ICON_NEW_CHAT;
-import static io.github.jeddict.ai.util.Icons.ICON_NEXT;
-import static io.github.jeddict.ai.util.Icons.ICON_PREV;
-import static io.github.jeddict.ai.util.Icons.ICON_SEND;
-import static io.github.jeddict.ai.util.Icons.ICON_SETTINGS;
-import static io.github.jeddict.ai.util.Icons.ICON_STATS;
-import static io.github.jeddict.ai.util.Icons.ICON_WEB;
-import io.github.jeddict.ai.util.Labels;
 import static io.github.jeddict.ai.util.MimeUtil.MIME_PLAIN_TEXT;
 import static io.github.jeddict.ai.util.ProjectUtil.getSourceFiles;
 import io.github.jeddict.ai.util.RandomTweetSelector;
 import io.github.jeddict.ai.util.StringUtil;
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Desktop;
-import java.awt.Dimension;
 import java.awt.EventQueue;
-import java.awt.FlowLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ComponentAdapter;
-import java.awt.event.ComponentEvent;
-import java.awt.event.KeyEvent;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -114,33 +84,17 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.prefs.Preferences;
-import javax.swing.AbstractAction;
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JEditorPane;
-import javax.swing.JFileChooser;
 import javax.swing.JFrame;
-import javax.swing.JPanel;
 import javax.swing.JScrollPane;
-import javax.swing.KeyStroke;
-import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
-import javax.swing.Timer;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
 import javax.swing.event.HyperlinkEvent;
-import javax.swing.text.Document;
 import org.apache.commons.lang3.StringUtils;
 import org.netbeans.api.java.source.JavaSource;
 import org.netbeans.api.java.source.TreePathHandle;
 import org.netbeans.api.java.source.WorkingCopy;
-import org.netbeans.api.options.OptionsDisplayer;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectInformation;
@@ -168,14 +122,7 @@ public class AssistantChatManager extends JavaFix {
     private TreePath treePath;
     private final Action action;
     private SQLCompletion sqlCompletion;
-    private ComponentAdapter buttonPanelAdapter;
-    private JComboBox<String> models;
-    private JComboBox<AssistantAction> actionComboBox;
-    private Timer timer;
-    private JButton prevButton, nextButton, openInBrowserButton, submitButton;//copyButton, saveButton,
-    private AssistantChat topComponent;
-    private JEditorPane questionPane;
-    private JScrollPane questionScrollPane;
+    private AssistantChat tc;
     private final List<Response> responseHistory = new ArrayList<>(); // TODO: to be reviewed/removed once all agents will use buit-in memory
     private int currentResponseIndex = -1;
     private String sourceCode;
@@ -188,13 +135,18 @@ public class AssistantChatManager extends JavaFix {
     private final PreferencesManager pm = PreferencesManager.getInstance();
     private Tree leaf;
     private final Map<String, String> params = new HashMap();
+    
+    private Future result;
+    private JeddictBrainListener handler;
+    
+    private boolean commitMessage, codeReview;
 
     /**
      * After a first kickoff in performRewrite the conversation can continue in
      * the chat window, handled in the handleQuestion() method. This requires
-     * the history to be retained, which is done by langchain4j's agents, as long
-     * as the same instance is used. Therefore testSpecialist, dbSpecialist,
-     * diffSpecialist keep the instance of the agent once created.
+     * the history to be retained, which is done by langchain4j's agents, as
+     * long as the same instance is used. Therefore testSpecialist,
+     * dbSpecialist, diffSpecialist keep the instance of the agent once created.
      */
     private TestSpecialist testSpecialist = null;
     private DBSpecialist dbSpecialist = null;
@@ -253,9 +205,9 @@ public class AssistantChatManager extends JavaFix {
     }
 
     public AssistantChatManager(
-        final Action action,
-        final Project project,
-        final Map<String, String> params
+            final Action action,
+            final Project project,
+            final Map<String, String> params
     ) {
         super(null);
         this.action = action;
@@ -279,12 +231,12 @@ public class AssistantChatManager extends JavaFix {
     }
 
     @Override
-    protected void performRewrite(JavaFix.TransformationContext tc) throws Exception {
-        WorkingCopy copy = tc.getWorkingCopy();
+    protected void performRewrite(JavaFix.TransformationContext context) throws Exception {
+        WorkingCopy copy = context.getWorkingCopy();
         if (copy.toPhase(JavaSource.Phase.RESOLVED).compareTo(JavaSource.Phase.RESOLVED) < 0) {
             return;
         }
-        leaf = tc.getPath().getLeaf();
+        leaf = context.getPath().getLeaf();
         this.fileObject = copy.getFileObject();
 
         if (leaf.getKind() == CLASS
@@ -302,22 +254,22 @@ public class AssistantChatManager extends JavaFix {
                 Set<FileObject> messageContextCopy = new HashSet<>(messageContext);
                 SwingUtilities.invokeLater(() -> {
                     displayHtmlContent(fileName, name + " AI Assistant");
-                    JeddictBrainListener handler = new JeddictBrainListener(topComponent) {
+                    JeddictBrainListener handler = new JeddictBrainListener(tc) {
                         @Override
                         public void onCompleteResponse(ChatResponse response) {
                             super.onCompleteResponse(response);
 
                             final Response r = new Response(null, response.aiMessage().text(), messageContextCopy);
-                            sourceCode = EditorUtil.updateEditors(null, getProject(), topComponent, r, getContextFiles());
+                            sourceCode = EditorUtil.updateEditors(null, getProject(), tc, r, getContextFiles());
 
                             // TODO: to be removed once all agents will use buit-in memory
                             responseHistory.add(r);
                             currentResponseIndex = responseHistory.size() - 1;
                         }
                     };
-                    final PreferencesManager pm = PreferencesManager.getInstance();
+                    String modelName = tc.getModelName();
                     if (action == Action.TEST) {
-                        final TestSpecialist pair = testSpecialist(handler);
+                        final TestSpecialist pair = testSpecialist(handler, modelName);
                         final String prompt = pm.getPrompts().get("test");
                         final String rules = pm.getSessionRules();
                         if (leaf instanceof MethodTree) {
@@ -327,7 +279,7 @@ public class AssistantChatManager extends JavaFix {
                         }
                     } else {
                         final String rules = pm.getSessionRules();
-                        final TechWriter pair = newJeddictBrain(handler, getModelName()).pairProgrammer(PairProgrammer.Specialist.TECHWRITER);
+                        final TechWriter pair = newJeddictBrain(handler, modelName).pairProgrammer(PairProgrammer.Specialist.TECHWRITER);
                         if (leaf instanceof MethodTree) {
                             async(() -> pair.describeCode(leaf.toString(), rules), handler);
                         } else {
@@ -353,8 +305,6 @@ public class AssistantChatManager extends JavaFix {
         handleQuestion(intitalCommitMessage, messageContext, true);
     }
 
-    private boolean commitMessage, codeReview;
-
     public void askQueryForCodeReview() {
         ProjectInformation info = ProjectUtils.getInformation(projectContext);
         String projectName = info.getDisplayName();
@@ -363,20 +313,150 @@ public class AssistantChatManager extends JavaFix {
         handleQuestion("", messageContext, true);
     }
 
+    private AssistantChat createChatInstance(String title, String type, Project project) {
+        BiConsumer<String, Set<FileObject>> queryUpdate = (newQuery, messageContext) -> {
+            handleQuestion(newQuery, messageContext, false);
+        };
+        return new AssistantChat(title, type, project) {
+            @Override
+            public void onChatReset() {
+                initialMessage();
+                responseHistory.clear(); // TODO: to be removed once all agents will use buit-in memory
+                currentResponseIndex = -1;
+                tc.updateButtons(currentResponseIndex > 0, currentResponseIndex < responseHistory.size() - 1);
+            }
+
+            @Override
+            public void onSubmit() {
+                if (result != null && !result.isDone()) {
+                    NotifyDescriptor.Confirmation confirmDialog = new NotifyDescriptor.Confirmation(
+                            "The AI Assistant is still processing the request. Do you want to cancel it?",
+                            "Interrupt AI Assistant",
+                            NotifyDescriptor.YES_NO_OPTION
+                    );
+                    Object answer = DialogDisplayer.getDefault().notify(confirmDialog);
+                    if (NotifyDescriptor.YES_OPTION.equals(answer)) {
+                        result.cancel(true);
+                        if (handler != null && handler.getProgressHandle() != null) {
+                            handler.getProgressHandle().finish();
+                        }
+                        result = null;
+                        stopLoading();
+                    }
+                } else {
+                    result = null;
+                    String question = tc.getQuestionPane().getText();
+                    Map<String, String> prompts = PreferencesManager.getInstance().getPrompts();
+
+                    //
+                    // To make sure the longest matching shortcut matches (i.e.
+                    // 'shortcutlong' is 'shortcut' is defined as well) let's
+                    // sort the shurtcuts in descending order; this guarantees
+                    // 'shortcut2' is matched before "shortcut" in the for loop
+                    //
+                    ArrayList<String> promptKeys = new ArrayList();
+                    promptKeys.addAll(prompts.keySet());
+                    promptKeys.sort(Comparator.reverseOrder());
+
+                    for (String key : promptKeys) {
+                        String prompt = prompts.get(key);
+
+                        String toReplace = "/" + key;
+
+                        if (question.contains(toReplace)) {
+                            question = question.replace(toReplace, prompt);
+                        }
+                    }
+                    if (!question.isEmpty()) {
+                        handleQuestion(question, messageContext, true);
+                    }
+                }
+            }
+
+            @Override
+            public void onPrev() {
+                // TODO: to be reviewed once all agents will use buit-in memory
+                if (currentResponseIndex > 0) {
+                    currentResponseIndex--;
+                    Response historyResponse = responseHistory.get(currentResponseIndex);
+                    sourceCode = EditorUtil.updateEditors(queryUpdate, getProject(), tc, historyResponse, getContextFiles());
+                    updateButtons(currentResponseIndex > 0, currentResponseIndex < responseHistory.size() - 1);
+                }
+            }
+
+            @Override
+            public void onNext() {
+                // TODO: to be reviewed once all agents will use buit-in memory
+                if (currentResponseIndex < responseHistory.size() - 1) {
+                    currentResponseIndex++;
+                    Response historyResponse = responseHistory.get(currentResponseIndex);
+                    sourceCode = EditorUtil.updateEditors(queryUpdate, getProject(), tc, historyResponse, getContextFiles());
+                    updateButtons(currentResponseIndex > 0, currentResponseIndex < responseHistory.size() - 1);
+                }
+            }
+
+            @Override
+            public void onSessionContext() {
+                Set<FileObject> fileObjects = getContextFiles();
+                String projectRootDir = null;
+                if (projectContext != null) {
+                    projectRootDir = projectContext.getProjectDirectory().getPath();
+                } else if (!fileObjects.isEmpty()) {
+                    projectRootDir = FileOwnerQuery.getOwner(fileObjects.iterator().next()).getProjectDirectory().getPath();
+                }
+
+                boolean enableRules = true;
+                String rules = pm.getSessionRules();
+                if (commitChanges != null) {
+                    rules = commitChanges;
+                    enableRules = false;
+                }
+                ContextDialog dialog = new ContextDialog((JFrame) SwingUtilities.windowForComponent(tc),
+                        enableRules, rules,
+                        projectRootDir, fileObjects);
+                dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
+                dialog.setSize(800, 800);
+                dialog.setLocationRelativeTo(SwingUtilities.windowForComponent(tc));
+                dialog.setVisible(true);
+                if (commitChanges == null) {
+                    pm.setSessionRules(dialog.getRules());
+                }
+            }
+
+            @Override
+            public void addFileTab(FileObject file) {
+                if (!messageContext.contains(file)) {
+                    messageContext.add(file);
+                     Consumer<FileObject> onCloseCallback =  f -> {
+                        messageContext.remove(f);
+                        tc.refreshFilePanel();
+                    };
+                    tc.addFile(file, onCloseCallback);
+                }
+            }
+
+            @Override
+            public void clearFileTab() {
+                messageContext.clear();
+                tc.clearFiles();
+            }
+
+        };
+    }
+
     public void displayHtmlContent(String filename, String title) {
-        Preferences prefs = Preferences.userNodeForPackage(AssistantChat.class);
-        prefs.putBoolean(AssistantChat.PREFERENCE_KEY, true);
-        topComponent = new AssistantChat(title, null, getProject());
-        topComponent.putClientProperty(ASSISTANT_CHAT_MANAGER_KEY, new WeakReference<>(AssistantChatManager.this));
-        JScrollPane scrollPane = new JScrollPane(topComponent.getParentPanel());
-        topComponent.add(scrollPane, BorderLayout.CENTER);
-        topComponent.add(createBottomPanel(null, filename, null), BorderLayout.SOUTH);
-        topComponent.open();
-        topComponent.requestActive();
+        tc = createChatInstance(title, null, getProject());
+        tc.putClientProperty(ASSISTANT_CHAT_MANAGER_KEY, new WeakReference<>(AssistantChatManager.this));
+        JScrollPane scrollPane = new JScrollPane(tc.getParentPanel());
+        tc.add(scrollPane, BorderLayout.CENTER);
+        tc.add(tc.createBottomPanel(null, filename, null), BorderLayout.SOUTH);
+        tc.open();
+        tc.requestActive();
+        tc.updateButtons(currentResponseIndex > 0, currentResponseIndex < responseHistory.size() - 1);
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             SwingUtilities.invokeLater(() -> {
-                if (topComponent != null) {
-                    topComponent.close();
+                if (tc != null) {
+                    tc.close();
                 }
             });
         }));
@@ -385,12 +465,10 @@ public class AssistantChatManager extends JavaFix {
     public void openChat(String type, final String query, String fileName, String title, Consumer<String> action) {
         SwingUtilities.invokeLater(() -> {
             new JeddictUpdateManager().checkForJeddictUpdate();
-            Preferences prefs = Preferences.userNodeForPackage(AssistantChat.class);
-            prefs.putBoolean(AssistantChat.PREFERENCE_KEY, true);
-            topComponent = new AssistantChat(title, type, getProject());
-            topComponent.setLayout(new BorderLayout());
-            topComponent.putClientProperty(ASSISTANT_CHAT_MANAGER_KEY, new WeakReference<>(AssistantChatManager.this));
-            JScrollPane scrollPane = new JScrollPane(topComponent.getParentPanel());
+            tc = createChatInstance(title, type, getProject());
+            tc.setLayout(new BorderLayout());
+            tc.putClientProperty(ASSISTANT_CHAT_MANAGER_KEY, new WeakReference<>(AssistantChatManager.this));
+            JScrollPane scrollPane = new JScrollPane(tc.getParentPanel());
             Color bgColor = getBackgroundColorFromMimeType(MIME_PLAIN_TEXT);
             boolean isDark = ColorUtil.isDarkColor(bgColor);
             if (isDark) {
@@ -398,25 +476,27 @@ public class AssistantChatManager extends JavaFix {
                 scrollPane.getVerticalScrollBar().setUI(new CustomScrollBarUI());
                 scrollPane.getHorizontalScrollBar().setUI(new CustomScrollBarUI());
             }
-            topComponent.add(scrollPane, BorderLayout.CENTER);
-            topComponent.add(createBottomPanel(type, fileName, action), BorderLayout.SOUTH);
+            tc.add(scrollPane, BorderLayout.CENTER);
+            tc.add(tc.createBottomPanel(type, fileName, action), BorderLayout.SOUTH);
             if (PreferencesManager.getInstance().getChatPlacement().equals("Left")) {
                 WindowManager.getDefault()
                         .findMode("explorer")
-                        .dockInto(topComponent);
+                        .dockInto(tc);
             } else if (PreferencesManager.getInstance().getChatPlacement().equals("Right")) {
                 WindowManager.getDefault()
                         .findMode("properties")
-                        .dockInto(topComponent);
+                        .dockInto(tc);
             }
-            topComponent.open();
-            topComponent.requestActive();
+            tc.open();
+            tc.requestActive();
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                if (topComponent != null) {
-                    SwingUtilities.invokeLater(() -> topComponent.close());
+                if (tc != null) {
+                    SwingUtilities.invokeLater(() -> tc.close());
                 }
             }));
-            questionPane.setText(query);
+            if (!query.isEmpty()) {
+                tc.getQuestionPane().setText(query);
+            }
             initialMessage();
         });
     }
@@ -426,7 +506,6 @@ public class AssistantChatManager extends JavaFix {
     }
 
     // --------------------------------------------------------- private methods
-
     private static final String HOME_PAGE = "<div style='margin:20px; padding:20px; border-radius:10px;'>"
             + "<div style='text-align:center;'>"
             + "👋 <strong>Welcome!</strong><br><br>"
@@ -440,8 +519,8 @@ public class AssistantChatManager extends JavaFix {
             + "</div>";
 
     private void initialMessage() {
-        JEditorPane init = topComponent.createHtmlPane(HOME_PAGE);
-        EventQueue.invokeLater(() -> questionPane.requestFocusInWindow());
+        JEditorPane init = tc.createHtmlPane(HOME_PAGE);
+        EventQueue.invokeLater(() -> tc.getQuestionPane().requestFocusInWindow());
         init.addHyperlinkListener(e -> {
             if (HyperlinkEvent.EventType.ACTIVATED.equals(e.getEventType())) {
                 String link = e.getDescription();
@@ -463,480 +542,6 @@ public class AssistantChatManager extends JavaFix {
         });
     }
 
-    private JPanel filePanel;
-    private MessageContextComponentAdapter filePanelAdapter;
-
-    public void addFileTab(FileObject file) {
-        if (!messageContext.contains(file)) {
-            messageContext.add(file);
-            FileTab fileTab = new FileTab(file, filePanel, f -> {
-                messageContext.remove(f);
-                filePanelAdapter.componentResized(null);
-            });
-            filePanel.add(fileTab);
-            filePanelAdapter.componentResized(null);
-            filePanel.revalidate();
-            filePanel.repaint();
-        }
-    }
-
-    public void clearFileTab() {
-        messageContext.clear();
-        filePanel.removeAll();
-        filePanelAdapter.componentResized(null);
-        filePanel.revalidate();
-        filePanel.repaint();
-    }
-
-    private JPanel createBottomPanel(String type, String fileName, Consumer<String> action) {
-        JPanel bottomPanel = new JPanel(new BorderLayout());
-
-        Color backgroundColor = getBackgroundColorFromMimeType(MIME_PLAIN_TEXT);
-        filePanel = new JPanel();
-        filePanelAdapter = new MessageContextComponentAdapter(filePanel);
-        filePanel.setLayout(new FlowLayout(FlowLayout.LEFT));
-        filePanel.setBackground(backgroundColor);
-        filePanel.setBorder(BorderFactory.createEmptyBorder());
-        filePanel.addComponentListener(filePanelAdapter);
-
-        JPanel buttonPanel = new JPanel(new BorderLayout());
-        buttonPanel.setBackground(backgroundColor);
-        buttonPanel.setBorder(BorderFactory.createEmptyBorder());
-
-        JPanel rightButtonPanel = new JPanel();
-        rightButtonPanel.setLayout(new FlowLayout(FlowLayout.RIGHT, 8, 1));
-        rightButtonPanel.setBackground(backgroundColor);
-        rightButtonPanel.setBorder(BorderFactory.createEmptyBorder());
-        buttonPanel.add(rightButtonPanel, BorderLayout.EAST);
-
-        JPanel leftButtonPanel = new JPanel();
-        leftButtonPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 8, 1));
-        leftButtonPanel.setBackground(backgroundColor);
-        leftButtonPanel.setBorder(BorderFactory.createEmptyBorder());
-        buttonPanel.add(leftButtonPanel, BorderLayout.WEST);
-
-        prevButton = createIconButton(Labels.PREV, ICON_PREV);
-        prevButton.setToolTipText("Previous Chat");
-        leftButtonPanel.add(prevButton);
-
-        nextButton = createIconButton(Labels.NEXT, ICON_NEXT);
-        nextButton.setToolTipText("Next Chat");
-        leftButtonPanel.add(nextButton);
-
-        openInBrowserButton = createIconButton(Labels.VIEW, ICON_WEB);
-        openInBrowserButton.setToolTipText("Open in Browser");
-        openInBrowserButton.setVisible(topComponent.getAllEditorCount() > 0);
-        leftButtonPanel.add(openInBrowserButton);
-
-        Set<String> modelsByProvider = getModelsByProvider(pm.getProvider());
-
-        modelsByProvider.add(pm.getModelName());
-        models = createStyledComboBox(modelsByProvider.toArray(new String[0]));
-        models.setSelectedItem(pm.getChatModel() != null ? pm.getChatModel() : pm.getModel());
-        models.setToolTipText("AI Models");
-        models.addActionListener(e -> {
-            String selectedModel = (String) models.getSelectedItem();
-            if (selectedModel != null) {
-                pm.setChatModel(selectedModel);
-            }
-        });
-        leftButtonPanel.add(models);
-
-        AssistantAction[] options = AssistantAction.values();
-        actionComboBox = createStyledComboBox(options);
-        String lastAction = pm.getAssistantAction();
-        if (lastAction != null) {
-            try {
-                actionComboBox.setSelectedItem(AssistantAction.valueOf(lastAction));
-            } catch (IllegalArgumentException ex) {
-                actionComboBox.setSelectedItem(AssistantAction.ASK);
-            }
-        } else {
-            actionComboBox.setSelectedItem(AssistantAction.ASK);
-        }
-        actionComboBox.setToolTipText("<html><b>Chat</b> – for general queries<br><b>Agent</b> – for file/project generation actions</html>");
-        actionComboBox.addActionListener(e -> {
-            AssistantAction selectedAction = (AssistantAction) actionComboBox.getSelectedItem();
-            if (selectedAction == AssistantAction.BUILD) {
-                if (getProject() == null) {
-                    Project[] openProjects = org.netbeans.api.project.ui.OpenProjects.getDefault().getOpenProjects();
-                    if (openProjects.length == 1) {
-                        project = openProjects[0];
-                        DialogDisplayer.getDefault().notify(
-                                new NotifyDescriptor.Message(
-                                        "Connected chat to project: " + ProjectUtils.getInformation(project).getDisplayName(),
-                                        NotifyDescriptor.INFORMATION_MESSAGE
-                                )
-                        );
-                    } else if (openProjects.length > 1) {
-                        JComboBox<Project> projectComboBox = new JComboBox<>(openProjects);
-                        projectComboBox.setRenderer(new javax.swing.ListCellRenderer<>() {
-                            private final javax.swing.DefaultListCellRenderer defaultRenderer = new javax.swing.DefaultListCellRenderer();
-
-                            @Override
-                            public java.awt.Component getListCellRendererComponent(javax.swing.JList<? extends Project> list, Project value, int index, boolean isSelected, boolean cellHasFocus) {
-                                String displayName = (value == null) ? "" : ProjectUtils.getInformation(value).getDisplayName();
-                                return defaultRenderer.getListCellRendererComponent(list, displayName, index, isSelected, cellHasFocus);
-                            }
-                        });
-                        NotifyDescriptor descriptor = new NotifyDescriptor(
-                                projectComboBox,
-                                "Select Project for AI Agent Mode",
-                                NotifyDescriptor.OK_CANCEL_OPTION,
-                                NotifyDescriptor.QUESTION_MESSAGE,
-                                null,
-                                NotifyDescriptor.OK_OPTION
-                        );
-                        Object dialogResult = DialogDisplayer.getDefault().notify(descriptor);
-                        if (NotifyDescriptor.OK_OPTION.equals(dialogResult)) {
-                            Project selectedProject = (Project) projectComboBox.getSelectedItem();
-                            if (selectedProject != null) {
-                                project = selectedProject;
-                                DialogDisplayer.getDefault().notify(
-                                        new NotifyDescriptor.Message(
-                                                "Connected chat to project: " + ProjectUtils.getInformation(project).getDisplayName(),
-                                                NotifyDescriptor.INFORMATION_MESSAGE
-                                        )
-                                );
-                            } else {
-                                actionComboBox.setSelectedItem(AssistantAction.ASK);
-                            }
-                        } else {
-                            actionComboBox.setSelectedItem(AssistantAction.ASK);
-                        }
-                    } else {
-                        NotifyDescriptor.Message msg = new NotifyDescriptor.Message(
-                                "To use AI agent mode, connect chat to any project by dropping any source file on chat window or start new chat from project/package/source file context.",
-                                NotifyDescriptor.WARNING_MESSAGE
-                        );
-                        DialogDisplayer.getDefault().notify(msg);
-                        actionComboBox.setSelectedItem(AssistantAction.ASK);
-                    }
-                }
-            }
-            selectedAction = (AssistantAction) actionComboBox.getSelectedItem();
-            if (selectedAction != null) {
-                pm.setAssistantAction(selectedAction.name());
-            }
-        });
-        leftButtonPanel.add(actionComboBox);
-
-        int javaEditorCount = topComponent.getAllCodeEditorCount();
-
-//        copyButton = createIconButton(Labels.COPY, ICON_COPY);
-//        copyButton.setToolTipText("Copy to clipboard");
-//        copyButton.setVisible(javaEditorCount > 0);
-//        leftButtonPanel.add(copyButton);
-//
-//        saveButton = createIconButton(Labels.SAVE, ICON_SAVE);
-//        saveButton.setToolTipText("Save as");
-//        saveButton.setVisible(javaEditorCount == 1);
-//        leftButtonPanel.add(saveButton);
-//        JButton saveToEditorButton = createIconButton(Labels.UPDATE + " " + fileName, ICON_UPDATE);
-//        saveToEditorButton.setToolTipText("Update " + fileName);
-//        saveToEditorButton.setVisible(fileName != null);
-//        leftButtonPanel.add(saveToEditorButton);
-        JButton showChartsButton = createIconButton(Labels.STATS, ICON_STATS);
-        showChartsButton.setToolTipText("Show Token Usage Charts");
-        rightButtonPanel.add(showChartsButton);
-        showChartsButton.addActionListener(e -> {
-            TokenUsageChartDialog.showDialog(SwingUtilities.getWindowAncestor(showChartsButton));
-        });
-
-        JButton optionsButton = createIconButton(Labels.SETTINGS, ICON_SETTINGS);
-        optionsButton.setToolTipText("Open Jeddict AI Assistant Settings");
-        optionsButton.addActionListener(e -> OptionsDisplayer.getDefault().open("JeddictAIAssistant"));
-        rightButtonPanel.add(optionsButton);
-
-        JButton messageContextButton = createIconButton(Labels.MESSAGE_CONTEXT, ICON_ATTACH);
-        messageContextButton.setToolTipText("Attach a file to current message context");
-        rightButtonPanel.add(messageContextButton);
-
-        JButton sessionContextButton = createIconButton(Labels.SESSION_CONTEXT, ICON_CONTEXT);
-        sessionContextButton.setToolTipText("View detailed context of the current chat session context.");
-        sessionContextButton.addActionListener(e -> showFilePathPopup());
-        rightButtonPanel.add(sessionContextButton);
-
-        JButton newChatButton = createIconButton(Labels.NEW_CHAT, ICON_NEW_CHAT);
-        newChatButton.setToolTipText("Start a new chat");
-        leftButtonPanel.add(newChatButton);
-
-        submitButton = createIconButton(Labels.SEND, ICON_SEND);
-        submitButton.setToolTipText("Ask a question");
-        rightButtonPanel.add(submitButton);
-
-        buttonPanelAdapter = new ComponentAdapter() {
-            boolean showOnlyIcons = false;
-
-            @Override
-            public void componentResized(ComponentEvent e) {
-                double totalButtonWidth = leftButtonPanel.getPreferredSize().width
-                        + rightButtonPanel.getPreferredSize().width;
-                if (showOnlyIcons) {
-                    totalButtonWidth = totalButtonWidth * 2;
-                }
-
-                int availableWidth = buttonPanel.getWidth();
-                showOnlyIcons = availableWidth < totalButtonWidth;
-
-                updateButton(prevButton, showOnlyIcons, ICON_PREV, Labels.PREV + " " + ICON_PREV);
-                updateButton(nextButton, showOnlyIcons, ICON_NEXT, Labels.NEXT + " " + ICON_NEXT);
-                updateButton(openInBrowserButton, showOnlyIcons, ICON_WEB, Labels.VIEW + " " + ICON_WEB);
-//                updateButton(copyButton, showOnlyIcons, ICON_COPY, Labels.COPY + " " + ICON_COPY);
-//                updateButton(saveButton, showOnlyIcons, ICON_SAVE, Labels.SAVE + " " + ICON_SAVE);
-//                updateButton(saveToEditorButton, showOnlyIcons, ICON_UPDATE, Labels.UPDATE + " " + ICON_UPDATE);
-                updateButton(newChatButton, showOnlyIcons, ICON_NEW_CHAT, Labels.NEW_CHAT + " " + ICON_NEW_CHAT);
-                updateButton(showChartsButton, showOnlyIcons, ICON_STATS, Labels.STATS + " " + ICON_STATS);
-                updateButton(optionsButton, showOnlyIcons, ICON_SETTINGS, Labels.SETTINGS + " " + ICON_SETTINGS);
-                updateButton(messageContextButton, showOnlyIcons, ICON_ATTACH, Labels.MESSAGE_CONTEXT + " " + ICON_ATTACH);
-                updateButton(sessionContextButton, showOnlyIcons, ICON_CONTEXT, Labels.SESSION_CONTEXT + " " + ICON_CONTEXT);
-                updateButton(submitButton, showOnlyIcons, ICON_SEND, Labels.SEND + " " + ICON_SEND);
-                updateCombobox(models, showOnlyIcons);
-                updateCombobox(actionComboBox, showOnlyIcons);
-                topComponent.updateUserPaneButtons(showOnlyIcons);
-
-            }
-
-            private void updateButton(JButton button, boolean iconOnly, String iconText, String fullText) {
-                button.setText(iconOnly ? iconText : fullText);
-            }
-
-            private <T> void updateCombobox(JComboBox<T> comboBox, boolean iconOnly) {
-                comboBox.putClientProperty("minimal", iconOnly);
-            }
-        };
-        buttonPanel.addComponentListener(buttonPanelAdapter);
-
-        questionPane = new JEditorPane();
-        questionPane.setEditorKit(createEditorKit("text/x-" + (type == null ? "java" : type)));
-        questionPane.putClientProperty("AI_QUERY_EDITOR", Boolean.TRUE);
-
-        Document doc = questionPane.getDocument();
-        doc.putProperty(JEDDICT_EDITOR_CALLBACK, (Consumer<FileObject>) this::addFileTab);
-
-        questionScrollPane = new JScrollPane(questionPane);
-        questionScrollPane.setBorder(BorderFactory.createEmptyBorder());
-        questionScrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
-        questionScrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        Color bgColor = getBackgroundColorFromMimeType(MIME_PLAIN_TEXT);
-        boolean isDark = ColorUtil.isDarkColor(bgColor);
-        if (isDark) {
-            questionScrollPane.getViewport().setBackground(Color.DARK_GRAY);
-            questionScrollPane.getVerticalScrollBar().setUI(new CustomScrollBarUI());
-            questionScrollPane.getHorizontalScrollBar().setUI(new CustomScrollBarUI());
-        }
-        questionPane.getDocument().addDocumentListener(new DocumentListener() {
-            @Override
-            public void insertUpdate(DocumentEvent e) {
-                updateHeight();
-            }
-
-            @Override
-            public void removeUpdate(DocumentEvent e) {
-                updateHeight();
-            }
-
-            @Override
-            public void changedUpdate(DocumentEvent e) {
-                updateHeight();
-            }
-        });
-
-//        copyButton.addActionListener(e -> {
-//            StringSelection stringSelection = new StringSelection(topComponent.getAllCodeEditorText());
-//            Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-//            clipboard.setContents(stringSelection, null);
-//        });
-//        saveButton.addActionListener(e -> {
-//            topComponent.saveAs(null, topComponent.getAllCodeEditorText());
-//        });
-//        saveToEditorButton.addActionListener(e -> {
-//            if (action != null) {
-//                action.accept(topComponent.getAllCodeEditorText());
-//            }
-//        });
-        newChatButton.addActionListener(e -> {
-            topComponent.clear();
-            topComponent.repaint();
-            initialMessage();
-            responseHistory.clear(); // TODO: to be removed once all agents will use buit-in memory
-            questionPane.setText("");
-            clearFileTab();
-            currentResponseIndex = -1;
-            updateButtons(prevButton, nextButton);
-        });
-
-        openInBrowserButton.addActionListener(e -> {
-            try {
-                File latestTempFile = File.createTempFile("gen-ai", ".html");
-                latestTempFile.deleteOnExit();
-                try ( FileWriter writer = new FileWriter(latestTempFile)) {
-                    writer.write(topComponent.getAllEditorText());
-                }
-                if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
-                    Desktop.getDesktop().browse(latestTempFile.toURI());
-                }
-            } catch (IOException ex) {
-                ex.printStackTrace();
-            }
-        });
-
-        submitButton.setAction(new AbstractAction() {
-            @Override
-            public void actionPerformed(ActionEvent ae) {
-                if (result != null && !result.isDone()) {
-                    NotifyDescriptor.Confirmation confirmDialog = new NotifyDescriptor.Confirmation(
-                            "The AI Assistant is still processing the request. Do you want to cancel it?",
-                            "Interrupt AI Assistant",
-                            NotifyDescriptor.YES_NO_OPTION
-                    );
-                    Object answer = DialogDisplayer.getDefault().notify(confirmDialog);
-                    if (NotifyDescriptor.YES_OPTION.equals(answer)) {
-                        result.cancel(true);
-                        if (handler != null && handler.getProgressHandle() != null) {
-                            handler.getProgressHandle().finish();
-                        }
-                        result = null;
-                        stopLoading();
-                    }
-                } else {
-                    result = null;
-                    String question = questionPane.getText();
-                    Map<String, String> prompts = PreferencesManager.getInstance().getPrompts();
-
-                    //
-                    // To make sure the longest matching shortcut matches (i.e.
-                    // 'shortcutlong' is 'shortcut' is defined as well) let's
-                    // sort the shurtcuts in descending order; this guarantees
-                    // 'shortcut2' is matched before "shortcut" in the for loop
-                    //
-                    ArrayList<String> promptKeys = new ArrayList();
-                    promptKeys.addAll(prompts.keySet());
-                    promptKeys.sort(Comparator.reverseOrder());
-
-                    for (String key: promptKeys) {
-                        String prompt = prompts.get(key);
-
-                        String toReplace = "/" + key;
-
-                        if (question.contains(toReplace)) {
-                            question = question.replace(toReplace, prompt);
-                        }
-                    }
-                    if (!question.isEmpty()) {
-                        handleQuestion(question, messageContext, true);
-                    }
-                }
-            }
-        });
-
-        BiConsumer<String, Set<FileObject>> queryUpdate = (newQuery, messageContext) -> {
-            handleQuestion(newQuery, messageContext, false);
-        };
-        prevButton.addActionListener(e -> {
-            // TODO: to be reviewed once all agents will use buit-in memory
-            if (currentResponseIndex > 0) {
-                currentResponseIndex--;
-                Response historyResponse = responseHistory.get(currentResponseIndex);
-                sourceCode = EditorUtil.updateEditors(queryUpdate, getProject(), topComponent, historyResponse, getContextFiles());
-                updateButtons(prevButton, nextButton);
-            }
-        });
-
-        nextButton.addActionListener(e -> {
-            // TODO: to be reviewed once all agents will use buit-in memory
-            if (currentResponseIndex < responseHistory.size() - 1) {
-                currentResponseIndex++;
-                Response historyResponse = responseHistory.get(currentResponseIndex);
-                sourceCode = EditorUtil.updateEditors(queryUpdate, getProject(), topComponent, historyResponse, getContextFiles());
-                updateButtons(prevButton, nextButton);
-            }
-        });
-
-        updateButtons(prevButton, nextButton);
-
-        messageContextButton.addActionListener(e -> {
-            JFileChooser fileChooser = new JFileChooser(pm.getLastBrowseDirectory());
-            int result = fileChooser.showOpenDialog(bottomPanel);
-            if (result == JFileChooser.APPROVE_OPTION) {
-                File selectedFile = fileChooser.getSelectedFile();
-                pm.setLastBrowseDirectory(selectedFile.getParent());
-                addFileTab(FileUtil.toFileObject(selectedFile));
-            }
-        });
-
-        FileTransferHandler.register(bottomPanel, this::addFileTab);
-        FileTransferHandler.register(questionPane, this::addFileTab);
-
-        //
-        // intercept shortkeys to submit the prompt
-        //
-        final String actionKey = "submit-prompt";
-
-        String shortcut = pm.getSubmitShortcut(); // e.g. "Ctrl + Enter", "Enter", "Shift + Enter", "Alt + Enter"
-
-        javax.swing.KeyStroke submitKey;
-        switch (shortcut) {
-            case "Enter":
-                submitKey = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0);
-                break;
-            case "Shift + Enter":
-                submitKey = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, KeyEvent.SHIFT_DOWN_MASK);
-                break;
-            default: // "Ctrl + Enter"
-                submitKey = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, KeyEvent.CTRL_DOWN_MASK);
-        }
-
-        final javax.swing.InputMap inputMap = questionPane.getInputMap(JComponent.WHEN_FOCUSED);
-        final javax.swing.ActionMap actionMap = questionPane.getActionMap();
-
-        inputMap.put(submitKey, actionKey);
-        actionMap.put(actionKey, submitButton.getAction());
-
-        // ---
-
-        bottomPanel.setLayout(new BoxLayout(bottomPanel, BoxLayout.Y_AXIS));
-        bottomPanel.add(filePanel);
-        bottomPanel.add(Box.createVerticalStrut(0));
-        bottomPanel.add(questionScrollPane);
-        bottomPanel.add(Box.createVerticalStrut(0));
-        bottomPanel.add(buttonPanel);
-
-        return bottomPanel;
-    }
-
-    private void startLoading() {
-        final String[] spinnerFrames = {"◐", "◓", "◑", "◒"};
-        final int[] frameIndex = {0};
-        timer = new Timer(200, e -> {
-            submitButton.setText(spinnerFrames[frameIndex[0]]);
-            frameIndex[0] = (frameIndex[0] + 1) % spinnerFrames.length;
-        });
-        timer.start();
-    }
-
-    private void stopLoading() {
-        timer.stop();
-    }
-
-    private void updateHeight() {
-        int lineHeight = questionPane.getFontMetrics(questionPane.getFont()).getHeight();
-        String text = questionPane.getText().trim();
-        int preferredHeight;
-        int linePadding = 5;
-        if (text.isEmpty()) {
-            preferredHeight = lineHeight * 3 + linePadding;
-        } else {
-            preferredHeight = questionPane.getPreferredSize().height;
-            preferredHeight = Math.max(lineHeight * 3 + linePadding,
-                    Math.min(preferredHeight, lineHeight * 12 + linePadding));
-        }
-
-        Dimension size = new Dimension(questionScrollPane.getWidth(), preferredHeight);
-        questionScrollPane.setPreferredSize(size);
-        questionScrollPane.revalidate();
-    }
-
     private Set<FileObject> getContextFiles() {
         Set<FileObject> fileObjects = new HashSet<>();
         if (projectContext != null) {
@@ -948,40 +553,10 @@ public class AssistantChatManager extends JavaFix {
         return fileObjects;
     }
 
-    private void showFilePathPopup() {
-        Set<FileObject> fileObjects = getContextFiles();
-        String projectRootDir = null;
-        if (projectContext != null) {
-            projectRootDir = projectContext.getProjectDirectory().getPath();
-        } else if (!fileObjects.isEmpty()) {
-            projectRootDir = FileOwnerQuery.getOwner(fileObjects.iterator().next()).getProjectDirectory().getPath();
-        }
-
-        boolean enableRules = true;
-        String rules = pm.getSessionRules();
-        if (commitChanges != null) {
-            rules = commitChanges;
-            enableRules = false;
-        }
-        ContextDialog dialog = new ContextDialog((JFrame) SwingUtilities.windowForComponent(topComponent),
-                enableRules, rules,
-                projectRootDir, fileObjects);
-        dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
-        dialog.setSize(800, 800);
-        dialog.setLocationRelativeTo(SwingUtilities.windowForComponent(topComponent));
-        dialog.setVisible(true);
-        if (commitChanges == null) {
-            pm.setSessionRules(dialog.getRules());
-        }
-    }
-
-    private Future result;
-    private JeddictBrainListener handler;
-
     private void handleQuestion(String question, Set<FileObject> messageContext, boolean newQuery) {
         result = executorService.submit(() -> {
             try {
-                startLoading();
+                tc.startLoading();
                 // TODO: to be removed once all agents will use buit-in memory
                 if (currentResponseIndex >= 0
                         && currentResponseIndex + 1 < responseHistory.size()) {
@@ -1002,7 +577,7 @@ public class AssistantChatManager extends JavaFix {
                     prevChatResponses = responseHistory.subList(startIndex, responseHistory.size());
                 }
                 Set<FileObject> messageContextCopy = new HashSet<>(messageContext);
-                handler = new JeddictBrainListener(topComponent) {
+                handler = new JeddictBrainListener(tc) {
                     @Override
                     public void onCompleteResponse(ChatResponse response) {
                         super.onCompleteResponse(response);
@@ -1011,7 +586,7 @@ public class AssistantChatManager extends JavaFix {
 
                         LOG.finest(() -> "response completed with\ntext\n" + textResponse + "\nand\ntooling\n" + toolingResponse);
 
-                        if(!toolingResponse.isEmpty()) {
+                        if (!toolingResponse.isEmpty()) {
                             textResponse.insert(0, "```tooling\n" + toolingResponse.toString() + "\n```\n");
                         }
                         final Response r = new Response(question, textResponse.toString(), messageContextCopy);
@@ -1027,34 +602,35 @@ public class AssistantChatManager extends JavaFix {
                             if (codeReview) {
                                 List<Review> reviews = parseReviewsFromYaml(r.getBlocks().get(0).getContent());
                                 String web = convertReviewsToHtml(reviews);
-                                topComponent.setReviews(reviews);
+                                tc.setReviews(reviews);
                                 r.getBlocks().clear();
                                 r.getBlocks().add(new Block("web", web));
                             }
-                            sourceCode = EditorUtil.updateEditors(queryUpdate, getProject(), topComponent, r, getContextFiles());
+                            sourceCode = EditorUtil.updateEditors(queryUpdate, getProject(), tc, r, getContextFiles());
 
-                            stopLoading();
-                            updateButtons(prevButton, nextButton);
-                            buttonPanelAdapter.componentResized(null);
+                            tc.stopLoading();
+                            tc.updateButtons(currentResponseIndex > 0, currentResponseIndex < responseHistory.size() - 1);
+                            tc.buttonPanelResized();
                         });
                     }
                 };
                 String response;
-                boolean agentEnabled = actionComboBox.getSelectedItem() == AssistantAction.BUILD;
+                boolean agentEnabled = tc.isAgentEnabled();
+                String modelName = tc.getModelName();
                 if (sqlCompletion != null) {
                     String context = sqlCompletion.getMetaData();
                     String messageScopeContent = getTextFilesContext(messageContext, getProject(), agentEnabled);
                     if (messageScopeContent != null && !messageScopeContent.isEmpty()) {
                         context = context + "\n\n Files:\n" + messageScopeContent;
                     }
-                    response = dbSpecialist(handler).assistDbMetadata(question, context, pm.getSessionRules());
+                    response = dbSpecialist(handler, modelName).assistDbMetadata(question, context, pm.getSessionRules());
                 } else if (commitMessage && commitChanges != null) {
                     String context = commitChanges;
                     String messageScopeContent = getTextFilesContext(messageContext, getProject(), agentEnabled);
                     if (messageScopeContent != null && !messageScopeContent.isEmpty()) {
                         context = context + "\n\n Files:\n" + messageScopeContent;
                     }
-                    response = diffSpecialist(handler).suggestCommitMessages(context, question);
+                    response = diffSpecialist(handler, modelName).suggestCommitMessages(context, question);
                 } else if (codeReview) {
                     String context = params.get("diff");
                     if (context == null) {
@@ -1064,9 +640,9 @@ public class AssistantChatManager extends JavaFix {
                     if (messageScopeContent != null && !messageScopeContent.isEmpty()) {
                         context = context + "\n\n Files:\n" + messageScopeContent;
                     }
-                    response = diffSpecialist(handler).reviewChanges(context, params.get("granularity"), params.get("feature"));
+                    response = diffSpecialist(handler, modelName).reviewChanges(context, params.get("granularity"), params.get("feature"));
                 } else if (action == Action.TEST) {
-                    final TestSpecialist pair = testSpecialist(handler);
+                    final TestSpecialist pair = testSpecialist(handler, modelName);
                     final String prompt = pm.getPrompts().get("test");
                     final String rules = pm.getSessionRules();
                     if (leaf instanceof MethodTree) {
@@ -1093,14 +669,14 @@ public class AssistantChatManager extends JavaFix {
                     List<String> images = new ArrayList<>();
                     images.addAll(sessionScopeImages);
                     images.addAll(messageScopeImages);
-                    response = newJeddictBrain(handler, getModelName())
-                        .generateDescription(getProject(), agentEnabled, sessionScopeContent + '\n' + messageScopeContent, null, images, prevChatResponses, question, pm.getSessionRules());
+                    response = newJeddictBrain(handler, modelName)
+                            .generateDescription(getProject(), agentEnabled, sessionScopeContent + '\n' + messageScopeContent, null, images, prevChatResponses, question, pm.getSessionRules());
                 } else if (treePath == null) {
-                    response = newJeddictBrain(handler, getModelName())
-                        .generateDescription(getProject(), null, null, null, prevChatResponses, question, pm.getSessionRules());
+                    response = newJeddictBrain(handler, modelName)
+                            .generateDescription(getProject(), null, null, null, prevChatResponses, question, pm.getSessionRules());
                 } else {
-                    response = newJeddictBrain(handler, getModelName())
-                        .generateDescription(getProject(), treePath.getCompilationUnit().toString(), treePath.getLeaf() instanceof MethodTree ? treePath.getLeaf().toString() : null, null, prevChatResponses, question, pm.getSessionRules());
+                    response = newJeddictBrain(handler, modelName)
+                            .generateDescription(getProject(), treePath.getCompilationUnit().toString(), treePath.getLeaf() instanceof MethodTree ? treePath.getLeaf().toString() : null, null, prevChatResponses, question, pm.getSessionRules());
                 }
 
                 //
@@ -1110,76 +686,60 @@ public class AssistantChatManager extends JavaFix {
                     handler.onCompleteResponse(ChatResponse.builder().aiMessage(new AiMessage(response)).build());
                 }
 
-                questionPane.setText("");
-                updateHeight();
-                clearFileTab();
+                tc.getQuestionPane().setText("");
+                tc.updateHeight();
+                tc.clearFileTab();
             } catch (Exception e) {
                 Exceptions.printStackTrace(e);
-                buttonPanelAdapter.componentResized(null);
+                tc.buttonPanelResized();
             }
         });
     }
 
-    private String getModelName() {
-        String modelName = (String) models.getSelectedItem();
-        if (modelName == null || modelName.isEmpty()) {
-            return pm.getModel();
-        }
-        return modelName;
-    }
-
-    private void updateButtons(JButton prevButton, JButton nextButton) {
-        // TODO: to be reviewed once all agents will use buit-in memory
-        prevButton.setVisible(currentResponseIndex > 0);
-        nextButton.setVisible(currentResponseIndex < responseHistory.size() - 1);
-
-        int javaEditorCount = topComponent.getAllCodeEditorCount();
-//        copyButton.setVisible(javaEditorCount > 0);
-//        saveButton.setVisible(javaEditorCount > 0);
-
-        openInBrowserButton.setVisible(topComponent.getAllEditorCount() > 0);
-    }
-
     private JeddictBrain newJeddictBrain(final JeddictBrainListener listener, final String name) {
         final JeddictBrain brain = new JeddictBrain(
-            name, PreferencesManager.getInstance().isStreamEnabled(), buildToolsList(project, listener));
+                name, PreferencesManager.getInstance().isStreamEnabled(), buildToolsList(project, listener));
         brain.addProgressListener(listener);
         return brain;
     }
 
     /**
      * Returns a TestSpecialist with memory reusing a previously created agent
-     * if <code>testSpecialist</code> is not null. If null, a new  instance is
+     * if <code>testSpecialist</code> is not null. If null, a new instance is
      * created.
      *
      * @return
      */
-    private TestSpecialist testSpecialist(final JeddictBrainListener listener) {
+    private TestSpecialist testSpecialist(final JeddictBrainListener listener, String modelName) {
 
-        if (testSpecialist != null) return testSpecialist;
+        if (testSpecialist != null) {
+            return testSpecialist;
+        }
 
         int memorySize = pm.getConversationContext();
 
-        JeddictBrain brain = newJeddictBrain(listener, getModelName());
+        JeddictBrain brain = newJeddictBrain(listener, modelName);
         brain.withMemory((memorySize < 0) ? Integer.MAX_VALUE : memorySize);
 
         return (testSpecialist = brain.pairProgrammer(PairProgrammer.Specialist.TEST));
     }
 
     /**
-     * Returns a DBSpecialist with memory reusing a previously created agent
-     * if <code>dbSpecialist</code> is not null. If null, a new  instance is
+     * Returns a DBSpecialist with memory reusing a previously created agent if
+     * <code>dbSpecialist</code> is not null. If null, a new instance is
      * created.
      *
      * @return
      */
-    private DBSpecialist dbSpecialist(final JeddictBrainListener listener) {
+    private DBSpecialist dbSpecialist(final JeddictBrainListener listener, String modelName) {
 
-        if (dbSpecialist != null) return dbSpecialist;
+        if (dbSpecialist != null) {
+            return dbSpecialist;
+        }
 
         int memorySize = pm.getConversationContext();
 
-        JeddictBrain brain = newJeddictBrain(listener, getModelName());
+        JeddictBrain brain = newJeddictBrain(listener, modelName);
         brain.withMemory((memorySize < 0) ? Integer.MAX_VALUE : memorySize);
 
         return (dbSpecialist = brain.pairProgrammer(PairProgrammer.Specialist.DB));
@@ -1187,25 +747,27 @@ public class AssistantChatManager extends JavaFix {
 
     /**
      * Returns a DiffSpecialist with memory reusing a previously created agent
-     * if <code>diffSpecialist</code> is not null. If null, a new  instance is
+     * if <code>diffSpecialist</code> is not null. If null, a new instance is
      * created.
      *
      * @return
      */
-    private DiffSpecialist diffSpecialist(final JeddictBrainListener listener) {
+    private DiffSpecialist diffSpecialist(final JeddictBrainListener listener, String modelName) {
 
-        if (diffSpecialist != null) return diffSpecialist;
+        if (diffSpecialist != null) {
+            return diffSpecialist;
+        }
 
         int memorySize = pm.getConversationContext();
 
-        JeddictBrain brain = newJeddictBrain(listener, getModelName());
+        JeddictBrain brain = newJeddictBrain(listener, modelName);
         brain.withMemory((memorySize < 0) ? Integer.MAX_VALUE : memorySize);
 
         return (diffSpecialist = brain.pairProgrammer(PairProgrammer.Specialist.DIFF));
     }
 
     private List<AbstractTool> buildToolsList(
-        final Project project, final JeddictBrainListener handler
+            final Project project, final JeddictBrainListener handler
     ) {
         if (project == null) {
             return List.of();
@@ -1214,21 +776,21 @@ public class AssistantChatManager extends JavaFix {
         // TODO: make this automatic with some discoverability approach (maybe
         // NB lookup registration?)
         //
-        final String basedir =
-            FileUtil.toPath(project.getProjectDirectory())
-            .toAbsolutePath().normalize()
-            .toString();
+        final String basedir
+                = FileUtil.toPath(project.getProjectDirectory())
+                        .toAbsolutePath().normalize()
+                        .toString();
 
         final List<AbstractTool> toolsList = List.of(
-            new ExecutionTools(
-                basedir, project.getProjectDirectory().getName(),
-                pm.getBuildCommand(project), pm.getTestCommand(project)
-            ),
-            new ExplorationTools(basedir, project.getLookup()),
-            new FileSystemTools(basedir),
-            new GradleTools(basedir),
-            new MavenTools(basedir),
-            new RefactoringTools(basedir)
+                new ExecutionTools(
+                        basedir, project.getProjectDirectory().getName(),
+                        pm.getBuildCommand(project), pm.getTestCommand(project)
+                ),
+                new ExplorationTools(basedir, project.getLookup()),
+                new FileSystemTools(basedir),
+                new GradleTools(basedir),
+                new MavenTools(basedir),
+                new RefactoringTools(basedir)
         );
 
         //
@@ -1250,7 +812,7 @@ public class AssistantChatManager extends JavaFix {
             protected void done() {
                 try {
                     handler.onCompleteResponse(
-                        ChatResponse.builder().aiMessage(new AiMessage(get())).build()
+                            ChatResponse.builder().aiMessage(new AiMessage(get())).build()
                     );
                 } catch (InterruptedException | ExecutionException x) {
                     //


### PR DESCRIPTION
Persist AI query pane state so typed input is saved on chat close and restored on reopen, preventing accidental loss of prompts and improving usability.

Note: This PR also moves all UI components to `AssistantChat.java`