### PR TITLE
Fix HumanInTheMiddleWrapper.getDummyArgsFor passing null for Project constructor arg

### DIFF
--- a/src/main/java/io/github/jeddict/ai/agent/HumanInTheMiddleWrapper.java
+++ b/src/main/java/io/github/jeddict/ai/agent/HumanInTheMiddleWrapper.java
@@ -26,6 +26,7 @@ import net.bytebuddy.implementation.bind.annotation.RuntimeType;
 import net.bytebuddy.matcher.ElementMatchers;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.function.Function;
@@ -112,13 +113,13 @@ public class HumanInTheMiddleWrapper {
                     .load(clazz.getClassLoader())
                     .getLoaded()
                     .getConstructor(clazz.getDeclaredConstructors()[0].getParameterTypes())
-                    .newInstance(getDummyArgsFor(clazz.getDeclaredConstructors()[0]));
+                    .newInstance(getDummyArgsFor(clazz.getDeclaredConstructors()[0], originalTool));
         } catch (Exception e) {
             throw new RuntimeException("Failed to wrap tool", e);
         }
     }
 
-    private Object[] getDummyArgsFor(Constructor<?> constructor) {
+    private Object[] getDummyArgsFor(Constructor<?> constructor, Object originalTool) {
         Object[] dummyArgs = new Object[constructor.getParameterCount()];
         Class<?>[] parameterTypes = constructor.getParameterTypes();
         for (int i = 0; i < parameterTypes.length; i++) {
@@ -128,10 +129,42 @@ public class HumanInTheMiddleWrapper {
             } else if (parameterTypes[i] == String.class) {
                 dummyArgs[i] = "."; // Satisfy AbstractTool's non-null basedir check
             } else {
-                dummyArgs[i] = null;
+                // For any other object parameter, try to get the actual value from
+                // the original tool via reflection so that the proxy subclass
+                // constructor does not fail on validation (e.g. ProjectTools(Project)
+                // calls basedirOf(project) which throws when project is null).
+                dummyArgs[i] = getFieldValueByType(parameterTypes[i], originalTool);
             }
         }
         return dummyArgs;
+    }
+
+    /**
+     * Searches the class hierarchy of {@code source} for the first field whose
+     * type is assignable to {@code type} and returns its value.  Returns
+     * {@code null} when no matching field is found or the field is inaccessible.
+     *
+     * <p>The check {@code type.isAssignableFrom(field.getType())} answers:
+     * "can a value of {@code field.getType()} be used where {@code type} is
+     * expected?" — i.e. the field's declared type is the same as or a subtype
+     * of the required parameter type.</p>
+     */
+    private Object getFieldValueByType(Class<?> type, Object source) {
+        Class<?> clazz = source.getClass();
+        while (clazz != null) {
+            for (Field field : clazz.getDeclaredFields()) {
+                if (type.isAssignableFrom(field.getType())) {
+                    try {
+                        field.setAccessible(true);
+                        return field.get(source);
+                    } catch (IllegalAccessException | SecurityException ignored) {
+                        // fall through to the next field / superclass
+                    }
+                }
+            }
+            clazz = clazz.getSuperclass();
+        }
+        return null;
     }
 
     /**

--- a/src/test/java/io/github/jeddict/ai/agent/HumanInTheMiddleWrapperProjectTest.java
+++ b/src/test/java/io/github/jeddict/ai/agent/HumanInTheMiddleWrapperProjectTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2025 the original author or authors from the Jeddict project (https://jeddict.github.io/).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.github.jeddict.ai.agent;
+
+import com.github.caciocavallosilano.cacio.ctc.junit.CacioTest;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import io.github.jeddict.ai.agent.project.MavenProjectTools;
+import io.github.jeddict.ai.agent.project.ProjectTools;
+import io.github.jeddict.ai.test.TestBase;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+/**
+ * Regression tests for {@link HumanInTheMiddleWrapper} wrapping project-aware
+ * tools whose constructors take {@code Project} (rather than a plain
+ * {@code String} basedir).  These tests require a headless AWT environment
+ * (hence {@code @CacioTest}).
+ */
+@CacioTest
+public class HumanInTheMiddleWrapperProjectTest extends TestBase {
+
+    private List<ToolExecutionRequest> interceptionEvents;
+    private Function<ToolExecutionRequest, Boolean> interceptor;
+
+    @BeforeEach
+    @Override
+    public void beforeEach() throws Exception {
+        super.beforeEach();
+        interceptionEvents = new ArrayList<>();
+        interceptor = execution -> {
+            interceptionEvents.add(execution);
+            return true;
+        };
+    }
+
+    @Test
+    void wrapping_ProjectTools_does_not_throw() throws Exception {
+        // Regression: wrapping a ProjectTools (whose constructor takes a Project
+        // and calls basedirOf(project)) must not throw
+        // "IllegalArgumentException: project cannot be null".
+        final ProjectTools original = ProjectTools.forProject(project(projectDir));
+        final ProjectTools wrapped = new HumanInTheMiddleWrapper(interceptor).wrap(original);
+        then(wrapped).isNotNull();
+    }
+
+    @Test
+    void wrapping_MavenProjectTools_does_not_throw() throws Exception {
+        // Same regression check for the MavenProjectTools subclass.
+        final MavenProjectTools original = new MavenProjectTools(project(projectDir));
+        final MavenProjectTools wrapped = new HumanInTheMiddleWrapper(interceptor).wrap(original);
+        then(wrapped).isNotNull();
+    }
+}


### PR DESCRIPTION
In INTERACTIVE mode, `JeddictBrain` wraps every tool with `HumanInTheMiddleWrapper` to apply human-in-the-middle approval. `ProjectTools` and all its subclasses take a `Project` as their constructor parameter rather than a plain `String` basedir. `getDummyArgsFor()` passed `null` for any non-primitive, non-String parameter, causing `ProjectTools(null)` → `basedirOf(null)` → `IllegalArgumentException: project cannot be null`.

## Changes

### `HumanInTheMiddleWrapper`

- `getDummyArgsFor(Constructor, Object originalTool)` — now accepts the original tool and, for non-primitive/non-String parameters, uses reflection to walk the tool's class hierarchy looking for a field whose type satisfies the required parameter type. The field's actual value is used instead of `null`. Falls back to `null` if no matching field is found.
- Added `getFieldValueByType(Class, Object)` helper — traverses `getDeclaredFields` + `getSuperclass`, catches both `IllegalAccessException` and `SecurityException`.

```java
// Before: always null for object params → ProjectTools(null) → IAE
} else {
    dummyArgs[i] = null;
}

// After: extract real value from the original tool via reflection
} else {
    dummyArgs[i] = getFieldValueByType(parameterTypes[i], originalTool);
}
```
