### PR TITLE
Fix for issue #308 The "chat with AI" is not reading the given file and fires an exception

### DIFF
--- a/src/main/java/io/github/jeddict/ai/hints/AssistantChatManager.java
+++ b/src/main/java/io/github/jeddict/ai/hints/AssistantChatManager.java
@@ -613,14 +613,14 @@ public class AssistantChatManager extends JavaFix {
             try {
                 if (sqlCompletion != null) {
                     String context = sqlCompletion.getMetaData();
-                    String messageScopeContent = getTextFilesContext(messageContext, getProject(), excludeJavadoc, includeFiles, agentEnabled);
+                    String messageScopeContent = getTextFilesContext(messageContext, getProject(), excludeJavadoc, includeFiles);
                     if (messageScopeContent != null && !messageScopeContent.isEmpty()) {
                         context = context + "\n\n Files:\n" + messageScopeContent;
                     }
                     response = dbSpecialist(listener, modelName).assistDbMetadata(question, context, sessionRules);
                 } else if (commitMessage && commitChanges != null) {
                     String context = commitChanges;
-                    String messageScopeContent = getTextFilesContext(messageContext, getProject(), excludeJavadoc, includeFiles, agentEnabled);
+                    String messageScopeContent = getTextFilesContext(messageContext, getProject(), excludeJavadoc, includeFiles);
                     if (messageScopeContent != null && !messageScopeContent.isEmpty()) {
                         context = context + "\n\n Files:\n" + messageScopeContent;
                     }
@@ -630,7 +630,7 @@ public class AssistantChatManager extends JavaFix {
                     if (context == null) {
                         context = "";
                     }
-                    final String messageScopeContent = getTextFilesContext(messageContext, projectContext, excludeJavadoc, includeFiles, agentEnabled);
+                    final String messageScopeContent = getTextFilesContext(messageContext, projectContext, excludeJavadoc, includeFiles);
                     if (messageScopeContent != null && !messageScopeContent.isEmpty()) {
                         context = context + "\n\n Files:\n" + messageScopeContent;
                     }
@@ -664,13 +664,13 @@ public class AssistantChatManager extends JavaFix {
                             sessionScopeContent = getProjectContext(mainSessionContext, selectedProject, excludeJavadoc, agentEnabled);
                         } else {
                             mainSessionContext = new HashSet(sessionContext);
-                            sessionScopeContent = getTextFilesContext(mainSessionContext, selectedProject, excludeJavadoc, includeFiles, agentEnabled);
+                            sessionScopeContent = getTextFilesContext(mainSessionContext, selectedProject, excludeJavadoc, includeFiles);
                         }
                         List<String> sessionScopeImages = getImageFilesContext(mainSessionContext, includeFiles);
 
                         Set<FileObject> fitleredMessageContext = new HashSet(messageContext);
                         fitleredMessageContext.removeAll(mainSessionContext);
-                        String messageScopeContent = getTextFilesContext(fitleredMessageContext, selectedProject, excludeJavadoc, includeFiles, agentEnabled);
+                        String messageScopeContent = getTextFilesContext(fitleredMessageContext, selectedProject, excludeJavadoc, includeFiles);
                         List<String> messageScopeImages = getImageFilesContext(fitleredMessageContext, includeFiles);
                         List<String> images = new ArrayList<>();
                         images.addAll(sessionScopeImages);

--- a/src/main/java/io/github/jeddict/ai/util/ContextHelper.java
+++ b/src/main/java/io/github/jeddict/ai/util/ContextHelper.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.netbeans.api.project.Project;
 import org.openide.filesystems.FileObject;
@@ -86,52 +87,44 @@ public class ContextHelper {
         final Set<FileObject> scope,
         final Project project,
         final boolean excludeJavadoc,
-        final List<String> includes,
-        final boolean agentEnabled
+        final List<String> includes
     ) {
         if (project == null) {
             return "";
         }
-        String projectDir = project.getProjectDirectory().getPath();
-        StringBuilder inputForAI = new StringBuilder();
+        final Logger LOG = Logger.getLogger(ContextHelper.class.getName());
 
-        if (agentEnabled) {
-            inputForAI.append("\nProject Dir: \n").append(projectDir).append("\n");
-            inputForAI.append("\nProject Files: \n");
-        }
-        Path projectPath = Paths.get(projectDir).toAbsolutePath().normalize();
+        final StringBuilder inputForAI = new StringBuilder();
 
         for (FileObject file : getFilesContextList(scope, includes)) {
-            if (agentEnabled) {
-                Path filePath = Paths.get(file.getPath()).toAbsolutePath().normalize();
-                Path relativePath;
-                try {
-                    relativePath = projectPath.relativize(filePath);
-                } catch (IllegalArgumentException e) {
-                    relativePath = filePath;
-                }
-                inputForAI.append(relativePath)
-                        .append("\n");
-            } else {
-                try {
-                    final String mimeType = Files.probeContentType(Path.of(file.toURI()));
+            LOG.finest(() -> "including file " + file + " in context");
+            try {
+                final String mimeType = Files.probeContentType(Path.of(file.toURI()));
 
-                    if (!mimeType.startsWith("image")) {
-                        String text = getLatestContent(file);
-                        if (text != null) {
-                            if ("java".equals(file.getExt()) && excludeJavadoc) {
-                                text = removeJavadoc(text);
-                            }
-                            inputForAI.append("File: ")
-                                    .append(file.getNameExt())
-                                    .append("\n")
-                                    .append(text)
-                                    .append("\n\n");
+                //
+                // mimeType can be null if probeContentType() is not able
+                // to determine the mime type; it should not happen often though
+                // as getFilesContextList() returnes files with a controlled
+                // list of extensions (via configuration)
+                //
+                if (mimeType != null && !mimeType.startsWith("image")) {
+                    String text = getLatestContent(file);
+                    if (text != null) {
+                        if ("java".equals(file.getExt()) && excludeJavadoc) {
+                            text = removeJavadoc(text);
                         }
+                        inputForAI.append("File: ")
+                                .append(file.getNameExt())
+                                .append("\n")
+                                .append(text)
+                                .append("\n\n");
                     }
-                } catch (Exception ex) {
-                    Exceptions.printStackTrace(ex);
+                } else {
+                    LOG.finest(() -> file + " discarted due to mime type " + mimeType);
                 }
+            } catch (Exception ex) {
+                LOG.finest(() -> "ups, error " + ex + " in including files in context");
+                Exceptions.printStackTrace(ex);
             }
         }
         return inputForAI.toString();


### PR DESCRIPTION
I wasn't able to reproduce the issue, it may be due to additional extensions given to the configuration. However, the bug is there and this PR proposes the fix.

In looking at the code and doing some experiments, though, I believe we should not send all files in Ask mode neither: if you do open a chat in ask mode with Jeddict-ai project you saturate the context window right away.