### PR TITLE
[Tools] #338 Interactive replace tools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <langchain4j.version>1.11.0</langchain4j.version>
+        <langchain4j.version>1.17.2</langchain4j.version>
+        <langchain4j.beta>beta27</langchain4j.beta>
         <netbeans.version>RELEASE300</netbeans.version>
     </properties>
 
@@ -296,7 +297,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-local-ai</artifactId>
-            <version>${langchain4j.version}-beta19</version>
+            <version>${langchain4j.version}-${langchain4j.beta}</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
@@ -316,7 +317,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-agentic</artifactId>
-            <version>${langchain4j.version}-beta19</version>
+            <version>${langchain4j.version}-${langchain4j.beta}</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/src/main/java/io/github/jeddict/ai/agent/AbstractInteractiveTool.java
+++ b/src/main/java/io/github/jeddict/ai/agent/AbstractInteractiveTool.java
@@ -15,16 +15,15 @@
  */
 package io.github.jeddict.ai.agent;
 
+import io.github.jeddict.ai.components.AssistantChat;
 import java.io.IOException;
 
-public abstract class AbstractBuildTool extends AbstractTool {
+public abstract class AbstractInteractiveTool extends AbstractTool {
 
-    private final String buildFile;
+     final AssistantChat assistantChat;
 
-    public AbstractBuildTool(final String basedir, final String buildFile) throws IOException {
+    public AbstractInteractiveTool(final String basedir, final AssistantChat assistantChat) throws IOException {
         super(basedir);
-        this.buildFile = buildFile;
+        this.assistantChat = assistantChat;
     }
-
-    
 }

--- a/src/main/java/io/github/jeddict/ai/agent/FileSystemTools.java
+++ b/src/main/java/io/github/jeddict/ai/agent/FileSystemTools.java
@@ -18,6 +18,7 @@ package io.github.jeddict.ai.agent;
 import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.exception.ToolExecutionException;
+import static io.github.jeddict.ai.agent.ToolPolicy.Policy.INTERACTIVE;
 import io.github.jeddict.ai.settings.PreferencesManager;
 import java.io.File;
 import java.io.IOException;
@@ -32,6 +33,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import static io.github.jeddict.ai.agent.ToolPolicy.Policy.READONLY;
 import static io.github.jeddict.ai.agent.ToolPolicy.Policy.READWRITE;
+import io.github.jeddict.ai.components.AssistantChat;
+import io.github.jeddict.ai.lang.InteractionMode;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -41,10 +44,10 @@ import org.apache.commons.lang3.StringUtils;
  * These tools allow language models to read, modify, and manage project files
  * in a controlled and safe way.
  */
-public class FileSystemTools extends AbstractCodeTool {
+public class FileSystemTools extends AbstractInteractiveTool {
 
-    public FileSystemTools(final String basedir) throws IOException {
-        super(basedir);
+    public FileSystemTools(final String basedir, final AssistantChat assistantChat) throws IOException {
+        super(basedir, assistantChat);
     }
 
     /**
@@ -287,8 +290,9 @@ public class FileSystemTools extends AbstractCodeTool {
      */
     @Tool(
     """
-    Replace parts of a file content matching a literal string with replacement text
-    with no user interaction. Special regex characters are escaped.
+    Replace parts of a file content matching a literal string with replacement text.
+    If the user modifies the content before saving, teh new content is returned.
+    Otherwise, `File updated` is returned.
     """)
     @ToolPolicy(READWRITE)
     public String replaceSnippetByLiteral(
@@ -311,7 +315,11 @@ public class FileSystemTools extends AbstractCodeTool {
      * @param replacement the replacement text
      * @return a status message
      */
-    @Tool("Replace parts of a file content matching a regex pattern with replacement text  with no user interaction")
+    @Tool("""
+        Replace parts of a file content matching a regex pattern with replacement text.
+        If the user modifies the content before saving, teh new content is returned.
+        Otherwise, `File updated` is returned.
+        """)
     @ToolPolicy(READWRITE)
     public String replaceSnippetByRegex(
         @P("the file pathname")
@@ -321,24 +329,39 @@ public class FileSystemTools extends AbstractCodeTool {
         @P("replacement text")
         final String replacement
     ) throws ToolExecutionException {
-        progress("🔄 Replacing text matching regex '" + regexPattern + "' in " + path);
+        final String FILE_UPDATED = "File updated";
 
+        progress("🔄 Replacing text matching regex '" + regexPattern + "' in " + path);
+        
         checkPath(path);
 
         try {
             final Path filePath = fullPath(path).toRealPath();
 
-            String original = Files.readString(filePath);
-            String modified = original.replaceAll(regexPattern, replacement);
+            final String original = Files.readString(filePath);
+            final String modified = original.replaceAll(regexPattern, replacement);
 
             if (original.equals(modified)) {
                 progress("❌ No matches found for regex '" + regexPattern + "' in " + path);
                 return "No matches found for pattern";
             }
 
+            //
+            // If the tool is invoched in iteraction mode INTERACTIVE, use the
+            // interactive tool instead.
+            //
+
+            if ((interaction == InteractionMode.INTERACTIVE) && (assistantChat != null)) {
+                InteractiveFileEditor delegate = new InteractiveFileEditor(basedir, assistantChat);
+                delegate.interaction(interaction);
+                final String modifiedContent = delegate.editFile(path, modified);
+                return modified.equals(modifiedContent) ? FILE_UPDATED : modifiedContent;
+            }
+
             Files.writeString(filePath, modified, StandardOpenOption.TRUNCATE_EXISTING);
             progress("✅ Snippet replaced");
-            return "Snippet replaced";
+
+            return FILE_UPDATED;
         } catch (IOException e) {
             progress("❌ Replacement failed: " + e);
             throw new ToolExecutionException("replacement failed: " + e);
@@ -352,14 +375,35 @@ public class FileSystemTools extends AbstractCodeTool {
      * @param newContent the new content to write
      * @return a status message
      */
-    @Tool("Replace the full content of a file by path with new text with no user interaction")
-    @ToolPolicy(READWRITE)
+    @Tool("""
+        Replace the full content of a file by path with new text.
+        If the user modifies the content before saving, teh new content is returned.
+        Otherwise, `File updated` is returned.
+    """)
+    @ToolPolicy(INTERACTIVE)
     public String replaceFileContent(
         @P("the file pathname")
         final String path,
         @P("new content")
         final String newContent
     ) throws ToolExecutionException {
+        final String FILE_UPDATED = "File updated";
+
+        //
+        // If the tool is invoched in iteraction mode INTERACTIVE, use the
+        // interactive tool instead.
+        //
+        if ((interaction == InteractionMode.INTERACTIVE) && (assistantChat != null)) {
+            try {
+                InteractiveFileEditor delegate = new InteractiveFileEditor(basedir, assistantChat);
+                delegate.interaction(interaction);
+                final String modifiedContent = delegate.editFile(path, newContent);
+                return newContent.equals(modifiedContent) ? FILE_UPDATED : modifiedContent;
+            } catch (IOException x) {
+                throw new ToolExecutionException("error in getting the content: " + x.getMessage());
+            }
+        }
+
         progress("🔄 Replacing content in " + path);
 
         checkPath(path);
@@ -367,7 +411,7 @@ public class FileSystemTools extends AbstractCodeTool {
         try {
             Files.writeString(fullPath(path), newContent, StandardOpenOption.TRUNCATE_EXISTING);
             progress("✅ File content replaced");
-            return "File updated";
+            return FILE_UPDATED;
         } catch (IOException e) {
             progress("❌ Replacement failed: " + e);
             throw new ToolExecutionException("replacement failed: " + e);

--- a/src/main/java/io/github/jeddict/ai/agent/GradleTools.java
+++ b/src/main/java/io/github/jeddict/ai/agent/GradleTools.java
@@ -32,10 +32,10 @@ import org.openide.filesystems.FileUtil;
  *
  * Author: Assistant
  */
-public class GradleTools extends AbstractBuildTool {
+public class GradleTools extends AbstractTool {
 
     public GradleTools(final String basedir) throws IOException {
-        super(basedir, "build.gradle");
+        super(basedir);
     }
 
     @Tool(

--- a/src/main/java/io/github/jeddict/ai/agent/InteractiveFileEditor.java
+++ b/src/main/java/io/github/jeddict/ai/agent/InteractiveFileEditor.java
@@ -35,13 +35,10 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * A tool for performing diff operations.
  */
-public class InteractiveFileEditor extends AbstractTool {
+public class InteractiveFileEditor extends AbstractInteractiveTool {
 
-    private final AssistantChat assistantChat;
-
-    public InteractiveFileEditor(String basedir, AssistantChat assistantChat) throws IOException {
-        super(basedir);
-        this.assistantChat = assistantChat;
+    public InteractiveFileEditor(final String basedir, final AssistantChat assistantChat) throws IOException {
+        super(basedir, assistantChat);
     }
 
     @Tool("""
@@ -79,7 +76,8 @@ public class InteractiveFileEditor extends AbstractTool {
         //
         if (interaction != InteractionMode.INTERACTIVE) {
             try {
-                final FileSystemTools delegate = new FileSystemTools(basedir);
+                final FileSystemTools delegate = new FileSystemTools(basedir, assistantChat);
+                delegate.interaction(interaction);
                 return delegate.createBinaryFile(path, content.getBytes());
             } catch (IOException x) {
                 throw new ToolExecutionException("error in getting the content: " + x.getMessage());

--- a/src/main/java/io/github/jeddict/ai/hints/AssistantChatManager.java
+++ b/src/main/java/io/github/jeddict/ai/hints/AssistantChatManager.java
@@ -28,10 +28,10 @@ import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import io.github.jeddict.ai.JeddictUpdateManager;
 import io.github.jeddict.ai.agent.AbstractTool;
-import io.github.jeddict.ai.agent.InteractiveFileEditor;
 import io.github.jeddict.ai.agent.ExplorationTools;
 import io.github.jeddict.ai.agent.FileSystemTools;
 import io.github.jeddict.ai.agent.GradleTools;
+import io.github.jeddict.ai.agent.InteractiveFileEditor;
 import io.github.jeddict.ai.agent.MavenTools;
 import io.github.jeddict.ai.agent.project.JakartaEEAdvisorMavenPluginTools;
 import io.github.jeddict.ai.agent.project.ProjectTools;
@@ -963,15 +963,8 @@ public class AssistantChatManager extends JavaFix {
         try {
             final List<AbstractTool> toolsList = new ArrayList();
 
-            //
-            // Tools for interactive mode
-            //
             toolsList.add(new InteractiveFileEditor(basedir, ac));
-
-            //
-            // Tools commmon to both AGENT and INTERACTIVE mode
-            //
-            toolsList.add(new FileSystemTools(basedir));
+            toolsList.add(new FileSystemTools(basedir, ac));
             toolsList.add(new MavenTools(project));
             toolsList.add(new ExplorationTools(basedir, project.getLookup()));
             // Add the project-type-specific tool (Maven, Gradle, or generic)

--- a/src/main/java/io/github/jeddict/ai/lang/JeddictBrain.java
+++ b/src/main/java/io/github/jeddict/ai/lang/JeddictBrain.java
@@ -27,6 +27,8 @@ import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.exception.ToolExecutionException;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.listener.ChatModelErrorContext;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
@@ -146,8 +148,8 @@ public class JeddictBrain implements PropertyChangeEmitter {
                     if (defaultInteraction != null) {
                         this.defaultInteraction = defaultInteraction;
                     }
-                    final HumanInTheMiddleWrapper wrapper =
-                        new HumanInTheMiddleWrapper(this.defaultInteraction);
+                    final HumanInTheMiddleWrapper wrapper
+                        = new HumanInTheMiddleWrapper(this.defaultInteraction);
 
                     this.tools = new ArrayList();
                     on(tools).loop(
@@ -212,30 +214,33 @@ public class JeddictBrain implements PropertyChangeEmitter {
             }
         }
 
-        final ChatModelListener modelListener = (specialist != PairProgrammer.Specialist.HACKER_WITHOUT_TOOLS) ?
-            new ChatModelListener() {
-                    @Override
-                    public void onRequest(ChatModelRequestContext ctx) {
-                        on(listeners).loop((l) -> l.onRequest(ctx.chatRequest()));
-                    }
+        final ChatModelListener modelListener = (specialist != PairProgrammer.Specialist.HACKER_WITHOUT_TOOLS)
+            ? new ChatModelListener() {
+            @Override
+            public void onRequest(ChatModelRequestContext ctx) {
+                on(listeners).loop((l) -> l.onRequest(ctx.chatRequest()));
+            }
 
-                    @Override
-                    public void onResponse(ChatModelResponseContext ctx) {
-                        on(listeners).loop((l) -> l.onResponse(ctx.chatRequest(), ctx.chatResponse()));
-                    }
-                }
+            @Override
+            public void onResponse(ChatModelResponseContext ctx) {
+                on(listeners).loop((l) -> l.onResponse(ctx.chatRequest(), ctx.chatResponse()));
+            }
+        }
             : new HackerWithoutTools.JeddictListenerAdapter(listeners);
 
-
         final AiServices builder = AiServices.builder(specialist.specialistClass);
-
+        if (streaming) {
+            builder.streamingChatModel(streamingModel(modelListener));
+        } else {
+            builder.chatModel(model(modelListener));
+        }
         if (memorySize > 0) {
             builder.chatMemory(MessageWindowChatMemory.withMaxMessages(memorySize));
         }
         if (specialist == PairProgrammer.Specialist.HACKER) {
             builder.tools(tools.toArray());
             builder.hallucinatedToolNameStrategy((exec) -> {
-                final ToolExecutionRequest ter = (ToolExecutionRequest)exec;
+                final ToolExecutionRequest ter = (ToolExecutionRequest) exec;
 
                 LOG.finest(() -> "tool hallucination: " + ter.name());
                 return ToolExecutionResultMessage.from(
@@ -249,23 +254,16 @@ public class JeddictBrain implements PropertyChangeEmitter {
         builder.toolArgumentsErrorHandler(this::toolArgumentsErrorHandler);
 
         if (specialist == PairProgrammer.Specialist.HACKER_WITHOUT_TOOLS) {
-            final HackerWithoutTools hacker = new HackerWithoutTools(model(false, modelListener), builder, tools);
+            final HackerWithoutTools hacker = new HackerWithoutTools(model(modelListener), builder, tools);
             hacker.maxIterations(25);
 
             return (T) hacker;
         }
 
-        if (streaming) {
-            builder.streamingChatModel(model(modelListener));
-        } else {
-            builder.chatModel(model(modelListener));
-        }
-        
         return (T) builder.build();
     }
 
     // -------------------------------------------------------- ToolErrorHandler
-
     public ToolErrorHandlerResult toolExecutionErrorHandler(final Throwable error, final ToolErrorContext context) {
         LOG.finest("tool execution error: %s (%s)".formatted(String.valueOf(error), String.valueOf(context)));
 
@@ -274,7 +272,7 @@ public class JeddictBrain implements PropertyChangeEmitter {
         //
         Throwable target = error;
         if (error instanceof InvocationTargetException) {
-            target = ((InvocationTargetException)error).getTargetException();
+            target = ((InvocationTargetException) error).getTargetException();
             if (target == null) {
                 target = error;
             }
@@ -287,15 +285,12 @@ public class JeddictBrain implements PropertyChangeEmitter {
     }
 
     // -------------------------------------------------------- ToolErrorHandler
-
-    public ToolErrorHandlerResult toolArgumentsErrorHandler(Throwable error,  ToolErrorContext context) {
+    public ToolErrorHandlerResult toolArgumentsErrorHandler(Throwable error, ToolErrorContext context) {
         LOG.finest("tool arguments error: %s (%s)".formatted(error, String.valueOf(context)));
         return ToolErrorHandlerResult.text(String.valueOf(error));
     }
 
-
     // --------------------------------------------------------- private methods
-
     protected boolean probeToolSupport() {
         final String LOG_MSG = "model %s %s tools execution";
 
@@ -304,8 +299,8 @@ public class JeddictBrain implements PropertyChangeEmitter {
         //
         if (probedModels.containsKey(modelName)) {
             final boolean toolsSupport = probedModels.get(modelName);
-            LOG.info(() ->
-                (LOG_MSG + " (cached)").formatted(modelName, (toolsSupport) ? "supports" : "does not support")
+            LOG.info(()
+                -> (LOG_MSG + " (cached)").formatted(modelName, (toolsSupport) ? "supports" : "does not support")
             );
             return toolsSupport;
         }
@@ -319,10 +314,9 @@ public class JeddictBrain implements PropertyChangeEmitter {
         try {
             final ToolsProbingTool probeTool = new ToolsProbingTool();
             final ToolsProber prober = AgenticServices.agentBuilder(ToolsProber.class)
-                .chatModel(model(false, null))
+                .chatModel(model(null))
                 .tools(probeTool)
                 .build();
-
 
             final boolean toolsSupport = prober.probe(probeTool.probeText);
 
@@ -334,8 +328,8 @@ public class JeddictBrain implements PropertyChangeEmitter {
 
             return toolsSupport;
         } catch (final Throwable t) {
-            LOG.severe(() ->
-                "error probing tool support, returning false %s\n%s".formatted(
+            LOG.severe(()
+                -> "error probing tool support, returning false %s\n%s".formatted(
                     t.toString(),
                     Arrays.toString(t.getStackTrace())
                 )
@@ -345,30 +339,9 @@ public class JeddictBrain implements PropertyChangeEmitter {
         return false;
     }
 
-
     // --------------------------------------------------------- private methods
 
-    /**
-     * Returns a streaming or not streaming model based on preferred type provided
-     * in the constructor (and saved in {@code streaming}
-     *
-     * @param <T>
-     *
-     * @return the model
-     */
-    private <T> T model(final ChatModelListener listener) {
-        return model(streaming, listener);
-    }
-
-    /**
-     * Returns a new streaming or not streaming model based on {@code useStreaming}
-     *
-     * @param <T>
-     * @param useStreaming
-     *
-     * @return the model
-     */
-    private <T> T model(final boolean useStreaming, final ChatModelListener listener) {
+    private StreamingChatModel streamingModel(final ChatModelListener listener)  {
         //
         // At the moment lanchain4j provides the chat request at an higher level
         // with the event AiServicesResponseEvent. This is fired only once the
@@ -376,78 +349,89 @@ public class JeddictBrain implements PropertyChangeEmitter {
         // and the response (see https://github.com/langchain4j/langchain4j/issues/4365)
         // However, we want to know when a request starts, so have to use a ChatModelListener
         //
-        final JeddictChatModelBuilder builder =
-            new JeddictChatModelBuilder(
-                this.modelName,
-                listener
-            );
+        final JeddictChatModelBuilder builder
+            = new JeddictChatModelBuilder(this.modelName, listener);
 
-        return (useStreaming) ? (T)builder.buildStreaming() : (T)builder.build();
+        return builder.buildStreaming();
     }
+
+    private ChatModel model(final ChatModelListener listener) {
+        //
+        // At the moment lanchain4j provides the chat request at an higher level
+        // with the event AiServicesResponseEvent. This is fired only once the
+        // request has been processed by the model and provides both the request
+        // and the response (see https://github.com/langchain4j/langchain4j/issues/4365)
+        // However, we want to know when a request starts, so have to use a ChatModelListener
+        //
+        final JeddictChatModelBuilder builder
+            = new JeddictChatModelBuilder(this.modelName, listener);
+
+        return builder.build();
+    }
+
 
     private List<AiServiceListener> allListeners() {
         return List.of(
             new AiServiceCompletedListener() {
-                @Override
-                public void onEvent(AiServiceCompletedEvent e) {
-                    //
-                    // e.resul() can be a ChatResponse or other objects (e.g.
-                    // a String). If not the former, let's convert it taking
-                    // the toString() of the object so that the listener can
-                    // rely on receive always the same object
-                    //
-                    e.result().ifPresentOrElse(obj -> {
-                        final ChatResponse result = (obj instanceof ChatResponse)
-                                                  ? (ChatResponse)obj
-                                                  : ChatResponse.builder().aiMessage(AiMessage.from(String.valueOf(obj))).build();
-                        LOG.finest(() ->
-                            "%s\n%s".formatted(String.valueOf(e.eventClass()), String.valueOf(result))
-                        );
-                        on(listeners).loop((l) -> l.onChatCompleted(result));
-                    }, () -> {
-                        LOG.finest(() ->
-                            "no result from the model..."
-                        );
-                    });
-                }
-            },
-            new AiServiceErrorListener() {
-                @Override
-                public void onEvent(final AiServiceErrorEvent e) {
-                    final Throwable t = e.error();
-                    LOG.finest(() -> e.eventClass() + "\n" + t);
-                    on(listeners).loop((l) -> l.onError(t));
-                }
-            },
-            new AiServiceStartedListener() {
-                @Override
-                public void onEvent(final AiServiceStartedEvent e) {
-                    final SystemMessage system = e.systemMessage().get();
-                    final UserMessage user = e.userMessage();
-                    LOG.finest(() ->
-                        "%s\n%s\n%s".formatted(String.valueOf(e.eventClass()), String.valueOf(system), String.valueOf(user))
+            @Override
+            public void onEvent(AiServiceCompletedEvent e) {
+                //
+                // e.resul() can be a ChatResponse or other objects (e.g.
+                // a String). If not the former, let's convert it taking
+                // the toString() of the object so that the listener can
+                // rely on receive always the same object
+                //
+                e.result().ifPresentOrElse(obj -> {
+                    final ChatResponse result = (obj instanceof ChatResponse)
+                        ? (ChatResponse) obj
+                        : ChatResponse.builder().aiMessage(AiMessage.from(String.valueOf(obj))).build();
+                    LOG.finest(()
+                        -> "%s\n%s".formatted(String.valueOf(e.eventClass()), String.valueOf(result))
                     );
-
-                    on(listeners).loop((l) -> l.onChatStarted(system, user));
-                }
-            },
-            new ToolExecutedEventListener() {
-                @Override
-                public void onEvent(final ToolExecutedEvent e) {
-                    final ToolExecutionRequest request = e.request();
-                    final String result = e.resultText();
-                    LOG.finest(() ->
-                        "%s\n%s\n%s".formatted(String.valueOf(e.eventClass()), String.valueOf(request), String.valueOf(result))
+                    on(listeners).loop((l) -> l.onChatCompleted(result));
+                }, () -> {
+                    LOG.finest(()
+                        -> "no result from the model..."
                     );
-
-                    on(listeners).loop((l) -> l.onToolExecuted(request, result));
-                }
+                });
             }
+        },
+            new AiServiceErrorListener() {
+            @Override
+            public void onEvent(final AiServiceErrorEvent e) {
+                final Throwable t = e.error();
+                LOG.finest(() -> e.eventClass() + "\n" + t);
+                on(listeners).loop((l) -> l.onError(t));
+            }
+        },
+            new AiServiceStartedListener() {
+            @Override
+            public void onEvent(final AiServiceStartedEvent e) {
+                final SystemMessage system = e.systemMessage().get();
+                final UserMessage user = e.userMessage();
+                LOG.finest(()
+                    -> "%s\n%s\n%s".formatted(String.valueOf(e.eventClass()), String.valueOf(system), String.valueOf(user))
+                );
+
+                on(listeners).loop((l) -> l.onChatStarted(system, user));
+            }
+        },
+            new ToolExecutedEventListener() {
+            @Override
+            public void onEvent(final ToolExecutedEvent e) {
+                final ToolExecutionRequest request = e.request();
+                final String result = e.resultText();
+                LOG.finest(()
+                    -> "%s\n%s\n%s".formatted(String.valueOf(e.eventClass()), String.valueOf(request), String.valueOf(result))
+                );
+
+                on(listeners).loop((l) -> l.onToolExecuted(request, result));
+            }
+        }
         );
     }
 
     // -------------------------------------------------- JeddictListenerAdapter
-
     static public class JeddictListenerAdapter implements ChatModelListener {
 
         final public JeddictBrainListener listener;

--- a/src/test/java/io/github/jeddict/ai/agent/FileSystemToolsTest.java
+++ b/src/test/java/io/github/jeddict/ai/agent/FileSystemToolsTest.java
@@ -20,7 +20,6 @@ import static io.github.jeddict.ai.agent.AbstractToolTest.TESTFILE;
 import io.github.jeddict.ai.test.TestBase;
 import io.github.jeddict.ai.lang.DummyJeddictBrainListener;
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -38,8 +37,9 @@ public class FileSystemToolsTest extends TestBase {
     protected DummyJeddictBrainListener listener = null;
 
     @BeforeEach
-    public void beforeEac() throws IOException {
-        tools = tools = new FileSystemTools(projectDir);
+    public void beforeEach() throws Exception {
+        super.beforeEach();
+        tools = new FileSystemTools(projectDir, null);
         listener = new DummyJeddictBrainListener();
         tools.addListener(listener);
     }
@@ -519,7 +519,7 @@ public class FileSystemToolsTest extends TestBase {
         final Path fullPath = projectPath.resolve(TESTFILE).normalize().toRealPath();
 
         then(tools.replaceSnippetByRegex(TESTFILE, "for.*ing", "for testing"))
-            .isEqualTo("Snippet replaced");
+            .isEqualTo("File updated");
         then(fullPath).content().isEqualTo("This is a test file content for testing.");
         thenProgressContains(listener.collector.get(0), "\n🔄 Replacing text matching regex 'for.*ing' in " + TESTFILE);
         thenProgressContains(listener.collector.get(1), "\n✅ Snippet replaced");

--- a/src/test/java/io/github/jeddict/ai/agent/ToolsProberTest.java
+++ b/src/test/java/io/github/jeddict/ai/agent/ToolsProberTest.java
@@ -17,12 +17,12 @@ package io.github.jeddict.ai.agent;
 
 import io.github.jeddict.ai.agent.pair.*;
 import dev.langchain4j.agentic.AgenticServices;
+import dev.langchain4j.agentic.agent.AgentInvocationException;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.listener.ChatModelRequestContext;
 import dev.langchain4j.model.chat.request.ToolChoice;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.UndeclaredThrowableException;
 import java.util.logging.Level;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
@@ -83,7 +83,7 @@ public class ToolsProberTest extends PairProgrammerTestBase {
     public void probing_illegal_values_throws_error() {
         for(String B: new String[] {null, "", "   ", " \n", "\t"}) {
             thenThrownBy( () -> prober.probe(B) )
-                .isInstanceOf(UndeclaredThrowableException.class)
+                .isInstanceOf(AgentInvocationException.class)
                 .cause()
                     .isInstanceOf(InvocationTargetException.class)
                     .cause()

--- a/src/test/java/io/github/jeddict/ai/agent/pair/HackerWithoutToolsTest.java
+++ b/src/test/java/io/github/jeddict/ai/agent/pair/HackerWithoutToolsTest.java
@@ -386,7 +386,7 @@ public class HackerWithoutToolsTest {
     @Test
     public void create_calculator_application() throws Exception {
         final HackerWithoutTools hacker = new HackerWithoutTools(MODEL, BUILDER,  List.of(
-            new FileSystemTools(basedir.toAbsolutePath().toString()),
+            new FileSystemTools(basedir.toAbsolutePath().toString(), null),
             new InteractiveFileEditor(basedir.toAbsolutePath().toString(), null)
         ));
 


### PR DESCRIPTION
This PR implements #338, which makes the tools `replaceContent` and `replaceSnippedByRegexp` interaction aware so that if they are executed in interactive mode they  use a diff view to review the changes.
